### PR TITLE
Fixed the way the kernel was read from the .xml file

### DIFF
--- a/python/kdsource/kdsource.py
+++ b/python/kdsource/kdsource.py
@@ -51,7 +51,7 @@ def load(xmlfilename, N=-1):
     root = tree.getroot()
     J = np.double(root.find("J").text)
     kelem = root.find("kernel")
-    if kelem:
+    if kelem is not None:
         kern = kelem.text
     else:
         print("No kernel specified. Using gaussian as default.")


### PR DESCRIPTION
Coming back to the PR https://github.com/KDSource/KDSource/pull/16, the function that opens the .xml files was not loading the kernel name. Now it's working properly. 