### PR TITLE
E0 max for Lethargy perturb - solution to issue #27

### DIFF
--- a/src/kdsource/geom.c
+++ b/src/kdsource/geom.c
@@ -147,7 +147,13 @@ int E_perturb(const Metric* metric, mcpl_particle_t* part, double bw, char kerne
 	return 0;
 }
 int Let_perturb(const Metric* metric, mcpl_particle_t* part, double bw, char kernel){
-	part->ekin *= exp(bw*metric->scaling[0] * rand_type(kernel));
+	float E = part->ekin;
+	E *= exp(bw*metric->scaling[0] * rand_type(kernel));
+	while(E > metric->params[0]){
+		E = part->ekin;
+		E *= exp(bw*metric->scaling[0] * rand_type(kernel));
+	}
+	part->ekin = E;
 	return 0;
 }
 


### PR DESCRIPTION
This is a solution for issue #27. To have a limit on the energy value after perturbing the variable in lethargy, E0 is used. In case an energy greater than E0 is generated, it is resampled. 