### PR TITLE
Change  name of MacOs tests in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
             python-version: 3.9,
           }
           - {
-            name: "MacOS_Latest",
+            name: "MacOS_13",
             os: macos-13,
             python-version: 3.9,
           }


### PR DESCRIPTION
Change the name of MacOs tests in ci.yml. The current name is MacOs latests, but the version is 13.