### PR TITLE
Proper floating point abs function in rand_epan C function (fixes #61)

### DIFF
--- a/clib/src/utils.c
+++ b/clib/src/utils.c
@@ -18,7 +18,7 @@ double rand_epan() {
   double x1 = (double)rand() / ((double)RAND_MAX / 2.0) - 1.0;
   double x2 = (double)rand() / ((double)RAND_MAX / 2.0) - 1.0;
   double x3 = (double)rand() / ((double)RAND_MAX / 2.0) - 1.0;
-  if (abs(x3) >= abs(x2) && abs(x3) >= abs(x1))
+  if (fabs(x3) >= fabs(x2) && fabs(x3) >= fabs(x1))
     return x2;
   else
     return x3;


### PR DESCRIPTION
abs -> fabs in rand_epan, resulting in the correct distribution (see #61).