### PR TITLE
Redesign RNG usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.config.python-version}}
 
-      - run: pip install .
+      - run: pip install "-Ccmake.define.KDS_STRICT=ON" .
       - run: pip show --files kdsource
       - run: kdsource-config -s
       - run: mcpl-config -s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,15 +204,14 @@ install(
 
 if ( KDS_STRICT )
   if ( MSVC )
-    message(FATAL_ERROR "KDS_STRICT not implemented for MSVC" )
+    #target_compile_options( kdsource PRIVATE /WX /W4 )
+    target_compile_options( kdsource PRIVATE /WX /W3 )
+  else()
+    target_compile_options(
+      kdsource PRIVATE -Wall -Wextra -Wpedantic -Wshadow -Wformat=2
+      -Wconversion -Wsign-conversion -Wnull-dereference -Werror
+    )
   endif()
-  target_compile_options(
-    kdsource PRIVATE
-    -Wall -Wextra -Wpedantic -Wshadow -Wformat=2 -Wconversion
-    -Wsign-conversion -Wnull-dereference
-    #-Wno-unused-variable
-  )
-  target_compile_options( kdsource PRIVATE -Werror )
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,8 +204,9 @@ install(
 
 if ( KDS_STRICT )
   if ( MSVC )
-    #target_compile_options( kdsource PRIVATE /WX /W4 )
-    target_compile_options( kdsource PRIVATE /WX /W3 )
+    #/disable warning 4996 for now, since it will require rewriting the sscanf
+    #usage.
+    target_compile_options( kdsource PRIVATE /WX /W4 /wd4996 )
   else()
     target_compile_options(
       kdsource PRIVATE -Wall -Wextra -Wpedantic -Wshadow -Wformat=2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 # See README.md file for installation instructions.                              #
 #                                                                                #
 # Written 2021 by O. I. Abbate.                                                  #
+# Major rewrite 2026 by T. Kittelmann.                                           #
 #                                                                                #
 ##################################################################################
 

--- a/clib/include/kdsource/geom.h
+++ b/clib/include/kdsource/geom.h
@@ -18,8 +18,9 @@
 
 typedef struct Metric Metric;
 
-typedef int (*PerturbFun)(const Metric *metric, mcpl_particle_t *part,
-                          double bw, char kernel);
+typedef double (*kds_rng_fct_t)(void);
+typedef int (*PerturbFun)(kds_rng_fct_t, const Metric *metric,
+                          mcpl_particle_t *part, double bw, char kernel);
 
 struct Metric {
   int dim;            // Dimension
@@ -27,6 +28,7 @@ struct Metric {
   PerturbFun perturb; // Perturbation function
   int nps;            // Number of metric parameters
   double *params;     // Metric parameters
+  kds_rng_fct_t rng;  // Random number generator
 };
 
 Metric *Metric_create(int dim, const double *scaling, PerturbFun perturb,
@@ -50,41 +52,41 @@ Geometry *Geom_create(int ord, Metric **metrics, double bw,
                       const char *bwfilename, char kernel, const double *trasl,
                       const double *rot);
 Geometry *Geom_copy(const Geometry *from);
-int Geom_perturb(const Geometry *geom, mcpl_particle_t *part);
+int Geom_perturb(kds_rng_fct_t, const Geometry *geom, mcpl_particle_t *part);
 int Geom_next(Geometry *geom, int loop);
 void Geom_destroy(Geometry *geom);
 
-int E_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-              char kernel);
-int Let_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                char kernel);
-int wl_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-               char kernel);
+int E_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+              double bw, char kernel);
+int Let_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                double bw, char kernel);
+int wl_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+               double bw, char kernel);
 
-int t_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-              char kernel);
-int Dec_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                char kernel);
+int t_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+              double bw, char kernel);
+int Dec_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                double bw, char kernel);
 
-int Vol_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                char kernel);
-int SurfXY_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                   char kernel);
-int SurfR_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                  char kernel);
-int SurfR2_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                   char kernel);
-int SurfCircle_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                       char kernel);
-int Guide_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                  char kernel);
+int Vol_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                double bw, char kernel);
+int SurfXY_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                   double bw, char kernel);
+int SurfR_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                  double bw, char kernel);
+int SurfR2_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                   double bw, char kernel);
+int SurfCircle_perturb(kds_rng_fct_t, const Metric *metric,
+                       mcpl_particle_t *part, double bw, char kernel);
+int Guide_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                  double bw, char kernel);
 
-int Isotrop_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                    char kernel);
-int Polar_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                  char kernel);
-int PolarMu_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                    char kernel);
+int Isotrop_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                    double bw, char kernel);
+int Polar_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                  double bw, char kernel);
+int PolarMu_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+                    double bw, char kernel);
 
 static const int _n_metrics = 14;
 static const char *_metric_names[] = {

--- a/clib/include/kdsource/geom.h
+++ b/clib/include/kdsource/geom.h
@@ -92,15 +92,8 @@ int Polar_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
 int PolarMu_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
                     double bw, char kernel);
 
-static const int _n_metrics = 14;
-static const char *_metric_names[] = {
-    "Energy", "Lethargy", "Wavelength", "Vol",   "SurfXY",
-    "SurfR",  "SurfR2",   "SurfCircle", "Guide", "Isotrop",
-    "Polar",  "PolarMu",  "Time",       "Decade"};
-static const PerturbFun _metric_perturbs[] = {
-    E_perturb,      Let_perturb,     wl_perturb,     Vol_perturb,
-    SurfXY_perturb, SurfR_perturb,   SurfR2_perturb, SurfCircle_perturb,
-    Guide_perturb,  Isotrop_perturb, Polar_perturb,  PolarMu_perturb,
-    t_perturb,      Dec_perturb};
+extern const int _n_metrics;
+extern const char *_metric_names[];
+extern const PerturbFun _metric_perturbs[];
 
 #endif

--- a/clib/include/kdsource/geom.h
+++ b/clib/include/kdsource/geom.h
@@ -18,7 +18,11 @@
 
 typedef struct Metric Metric;
 
+#ifndef KDS_RNG_FCT
+#define KDS_RNG_FCT
 typedef double (*kds_rng_fct_t)(void);
+#endif
+
 typedef int (*PerturbFun)(kds_rng_fct_t, const Metric *metric,
                           mcpl_particle_t *part, double bw, char kernel);
 

--- a/clib/include/kdsource/kdsource.h.in
+++ b/clib/include/kdsource/kdsource.h.in
@@ -55,7 +55,7 @@ KDSource *KDS_open(const char *xmlfilename);
 int KDS_rand_sample2(kds_rng_fct_t, KDSource *kds, mcpl_particle_t *part,
                      int perturb, double w_crit, WeightFun bias, int loop);
 int KDS_rand_sample(kds_rng_fct_t, KDSource *kds, mcpl_particle_t *part);
-double KDS_w_mean(KDSource *kds, int N, WeightFun bias);
+double KDS_rand_w_mean(kds_rng_fct_t, KDSource *kds, int N, WeightFun bias);
 void KDS_destroy(KDSource *kds);
 
 typedef struct MultiSource {
@@ -71,7 +71,7 @@ MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws);
 int MS_rand_sample2(kds_rng_fct_t, MultiSource *ms, mcpl_particle_t *part,
                     int perturb, double w_crit, WeightFun bias, int loop);
 int MS_rand_sample(kds_rng_fct_t, MultiSource *ms, mcpl_particle_t *part);
-double MS_w_mean(MultiSource *ms, int N, WeightFun bias);
+double MS_rand_w_mean(kds_rng_fct_t, MultiSource *ms, int N, WeightFun bias);
 void MS_destroy(MultiSource *ms);
 
 // Backwards compatibility sampling functions without RNG control (not really
@@ -82,5 +82,7 @@ int KDS_sample(KDSource *kds, mcpl_particle_t *part);
 int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
                double w_crit, WeightFun bias, int loop);
 int MS_sample(MultiSource *ms, mcpl_particle_t *part);
+double KDS_w_mean(KDSource *kds, int N, WeightFun bias);
+double MS_w_mean(MultiSource *ms, int N, WeightFun bias);
 
 #endif

--- a/clib/include/kdsource/kdsource.h.in
+++ b/clib/include/kdsource/kdsource.h.in
@@ -20,12 +20,12 @@
 /*                                                                                 */
 /***********************************************************************************/
 
+#include "kdsource/geom.h"
+#include "kdsource/plist.h"
+#include "kdsource/utils.h"
 #include "mcpl.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "kdsource/utils.h"
-#include "kdsource/geom.h"
-#include "kdsource/plist.h"
 
 #define KDSOURCE_VERSION_MAJOR @KDSource_VERSION_MAJOR@
 #define KDSOURCE_VERSION_MINOR @KDSource_VERSION_MINOR@
@@ -35,6 +35,8 @@
 
 #define MAX_RESAMPLES 1000000
 #define NAME_MAX_LEN 256
+
+typedef double (*kds_rng_fct_t)(void);
 
 typedef double (*WeightFun)(const mcpl_particle_t *part);
 
@@ -47,9 +49,9 @@ typedef struct KDSource {
 
 KDSource *KDS_create(double J, char kernel, PList *plist, Geometry *geom);
 KDSource *KDS_open(const char *xmlfilename);
-int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
-                double w_crit, WeightFun bias, int loop);
-int KDS_sample(KDSource *kds, mcpl_particle_t *part);
+int KDS_rand_sample2(kds_rng_fct_t, KDSource *kds, mcpl_particle_t *part,
+                     int perturb, double w_crit, WeightFun bias, int loop);
+int KDS_rand_sample(kds_rng_fct_t, KDSource *kds, mcpl_particle_t *part);
 double KDS_w_mean(KDSource *kds, int N, WeightFun bias);
 void KDS_destroy(KDSource *kds);
 
@@ -63,10 +65,19 @@ typedef struct MultiSource {
 
 MultiSource *MS_create(int len, KDSource **s, const double *ws);
 MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws);
+int MS_rand_sample2(kds_rng_fct_t, MultiSource *ms, mcpl_particle_t *part,
+                    int perturb, double w_crit, WeightFun bias, int loop);
+int MS_rand_sample(kds_rng_fct_t, MultiSource *ms, mcpl_particle_t *part);
+double MS_w_mean(MultiSource *ms, int N, WeightFun bias);
+void MS_destroy(MultiSource *ms);
+
+// Backwards compatibility sampling functions without RNG control (not really
+// recommended):
+int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
+                double w_crit, WeightFun bias, int loop);
+int KDS_sample(KDSource *kds, mcpl_particle_t *part);
 int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
                double w_crit, WeightFun bias, int loop);
 int MS_sample(MultiSource *ms, mcpl_particle_t *part);
-double MS_w_mean(MultiSource *ms, int N, WeightFun bias);
-void MS_destroy(MultiSource *ms);
 
 #endif

--- a/clib/include/kdsource/kdsource.h.in
+++ b/clib/include/kdsource/kdsource.h.in
@@ -36,7 +36,10 @@
 #define MAX_RESAMPLES 1000000
 #define NAME_MAX_LEN 256
 
+#ifndef KDS_RNG_FCT
+#define KDS_RNG_FCT
 typedef double (*kds_rng_fct_t)(void);
+#endif
 
 typedef double (*WeightFun)(const mcpl_particle_t *part);
 

--- a/clib/include/kdsource/utils.h
+++ b/clib/include/kdsource/utils.h
@@ -14,10 +14,12 @@
 /*                                                                                 */
 /***********************************************************************************/
 
-double rand_norm();
-double rand_epan();
-double rand_box();
-double rand_type(char kernel);
+// random sampling:
+typedef double (*kds_rng_fct_t)(void);
+double kds_rand_norm(kds_rng_fct_t);
+double kds_rand_epan(kds_rng_fct_t);
+double kds_rand_box(kds_rng_fct_t);
+double kds_rand_type(kds_rng_fct_t, char kernel);
 
 double *traslv(double *vect, const double *trasl, int inverse);
 double *rotv(double *vect, const double *rotvec, int inverse);

--- a/clib/include/kdsource/utils.h
+++ b/clib/include/kdsource/utils.h
@@ -15,7 +15,10 @@
 /***********************************************************************************/
 
 // random sampling:
+#ifndef KDS_RNG_FCT
+#define KDS_RNG_FCT
 typedef double (*kds_rng_fct_t)(void);
+#endif
 double kds_rand_norm(kds_rng_fct_t);
 double kds_rand_epan(kds_rng_fct_t);
 double kds_rand_box(kds_rng_fct_t);

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -119,7 +119,8 @@ Geometry *Geom_copy(const Geometry *from) {
   return geom;
 }
 
-int Geom_perturb(const Geometry *geom, mcpl_particle_t *part) {
+int Geom_perturb(kds_rng_fct_t rng, const Geometry *geom,
+                 mcpl_particle_t *part) {
   int i, ret = 0;
   if (geom->trasl)
     traslv(part->position, geom->trasl, 1);
@@ -128,7 +129,7 @@ int Geom_perturb(const Geometry *geom, mcpl_particle_t *part) {
     rotv(part->direction, geom->rot, 1);
   }
   for (i = 0; i < geom->ord; i++)
-    ret += geom->ms[i]->perturb(geom->ms[i], part, geom->bw, geom->kernel);
+    ret += geom->ms[i]->perturb(rng, geom->ms[i], part, geom->bw, geom->kernel);
   if (geom->rot) {
     rotv(part->position, geom->rot, 0);
     rotv(part->direction, geom->rot, 0);
@@ -170,67 +171,67 @@ void Geom_destroy(Geometry *geom) {
   free(geom);
 }
 
-int E_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-              char kernel) {
-  part->ekin += bw * metric->scaling[0] * rand_type(kernel);
+int E_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+              double bw, char kernel) {
+  part->ekin += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
   if (part->ekin < 0)
     part->ekin *= -1;
   return 0;
 }
 
-int Let_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                char kernel) {
+int Let_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+                double bw, char kernel) {
   double E = part->ekin;
-  E *= exp(bw * metric->scaling[0] * rand_type(kernel));
+  E *= exp(bw * metric->scaling[0] * kds_rand_type(rng, kernel));
   while (E > metric->params[0]) {
     E = part->ekin;
-    E *= exp(bw * metric->scaling[0] * rand_type(kernel));
+    E *= exp(bw * metric->scaling[0] * kds_rand_type(rng, kernel));
   }
   part->ekin = E;
   return 0;
 }
 
-int wl_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-               char kernel) {
+int wl_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+               double bw, char kernel) {
   double wl = 9.045 / sqrt(part->ekin * 1e9);
-  double wl2 = wl + bw * metric->scaling[0] * rand_type(kernel);
+  double wl2 = wl + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
   part->ekin = 81.82e-9 / (wl2 * wl2);
   if (part->ekin < 0)
     part->ekin *= -1;
   return 0;
 }
 
-int t_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-              char kernel) {
-  part->time += bw * metric->scaling[0] * rand_type(kernel);
+int t_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+              double bw, char kernel) {
+  part->time += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
   return 0;
 }
-int Dec_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                char kernel) {
-  part->time *= pow(10, bw * metric->scaling[0] * rand_type(kernel));
+int Dec_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+                double bw, char kernel) {
+  part->time *= pow(10, bw * metric->scaling[0] * kds_rand_type(rng, kernel));
   return 0;
 }
 
-int Vol_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                char kernel) {
+int Vol_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+                double bw, char kernel) {
   double xmin = metric->params[0], xmax = metric->params[1];
   double ymin = metric->params[2], ymax = metric->params[3];
   double zmin = metric->params[4], zmax = metric->params[5];
-  part->position[0] += bw * metric->scaling[0] * rand_type(kernel);
+  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
   while ((part->position[0] < xmin) || (part->position[0] > xmax)) {
     if (part->position[0] < xmin)
       part->position[0] += 2 * (xmin - part->position[0]);
     else
       part->position[0] -= 2 * (part->position[0] - xmax);
   }
-  part->position[1] += bw * metric->scaling[1] * rand_type(kernel);
+  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, kernel);
   while ((part->position[1] < ymin) || (part->position[1] > ymax)) {
     if (part->position[1] < ymin)
       part->position[1] += 2 * (ymin - part->position[1]);
     else
       part->position[1] -= 2 * (part->position[1] - ymax);
   }
-  part->position[2] += bw * metric->scaling[2] * rand_type(kernel);
+  part->position[2] += bw * metric->scaling[2] * kds_rand_type(rng, kernel);
   while ((part->position[2] < zmin) || (part->position[2] > zmax)) {
     if (part->position[2] < zmin)
       part->position[2] += 2 * (zmin - part->position[2]);
@@ -239,18 +240,18 @@ int Vol_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
   }
   return 0;
 }
-int SurfXY_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                   char kernel) {
+int SurfXY_perturb(kds_rng_fct_t rng, const Metric *metric,
+                   mcpl_particle_t *part, double bw, char kernel) {
   double xmin = metric->params[0], xmax = metric->params[1];
   double ymin = metric->params[2], ymax = metric->params[3];
-  part->position[0] += bw * metric->scaling[0] * rand_type(kernel);
+  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
   while ((part->position[0] < xmin) || (part->position[0] > xmax)) {
     if (part->position[0] < xmin)
       part->position[0] += 2 * (xmin - part->position[0]);
     else
       part->position[0] -= 2 * (part->position[0] - xmax);
   }
-  part->position[1] += bw * metric->scaling[1] * rand_type(kernel);
+  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, kernel);
   while ((part->position[1] < ymin) || (part->position[1] > ymax)) {
     if (part->position[1] < ymin)
       part->position[1] += 2 * (ymin - part->position[1]);
@@ -259,8 +260,8 @@ int SurfXY_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
   }
   return 0;
 }
-int SurfR_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                  char kernel) {
+int SurfR_perturb(kds_rng_fct_t rng, const Metric *metric,
+                  mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
   double rho, psi, rho2, psi2;
@@ -269,8 +270,9 @@ int SurfR_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
              part->position[1] * part->position[1]);
   psi = atan2(part->position[1], part->position[0]);
 
-  rho2 = rho + bw * metric->scaling[0] * rand_type(kernel);
-  psi2 = psi + bw * metric->scaling[1] * KDS_PI / 180 * rand_type(kernel);
+  rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  psi2 =
+      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
 
   while ((rho2 < rho_min) || (rho2 > rho_max)) {
     if (rho2 < rho_min)
@@ -290,8 +292,8 @@ int SurfR_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
   part->position[1] = rho2 * sin(psi2);
   return 0;
 }
-int SurfR2_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                   char kernel) {
+int SurfR2_perturb(kds_rng_fct_t rng, const Metric *metric,
+                   mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
   double rho, psi, rho2, psi2;
@@ -303,8 +305,9 @@ int SurfR2_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
         part->position[1] * part->position[1];
   psi = atan2(part->position[1], part->position[0]);
 
-  rho2 = rho + bw * metric->scaling[0] * rand_type(kernel);
-  psi2 = psi + bw * metric->scaling[1] * KDS_PI / 180 * rand_type(kernel);
+  rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  psi2 =
+      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
 
   while ((rho2 < rho_min) || (rho2 > rho_max)) {
     if (rho2 < rho_min)
@@ -324,14 +327,14 @@ int SurfR2_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
   part->position[1] = sqrt(rho2) * sin(psi2);
   return 0;
 }
-int SurfCircle_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                       char kernel) {
+int SurfCircle_perturb(kds_rng_fct_t rng, const Metric *metric,
+                       mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
   double x, y, rho2 = 0, psi2 = 0;
 
-  x = part->position[0] + bw * metric->scaling[0] * rand_type(kernel);
-  y = part->position[1] + bw * metric->scaling[1] * rand_type(kernel);
+  x = part->position[0] + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  y = part->position[1] + bw * metric->scaling[1] * kds_rand_type(rng, kernel);
 
   rho2 = sqrt(x * x + y * y);
   psi2 = atan2(y, x);
@@ -353,8 +356,8 @@ int SurfCircle_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
   part->position[1] = rho2 * sin(psi2);
   return 0;
 }
-int Guide_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                  char kernel) {
+int Guide_perturb(kds_rng_fct_t rng, const Metric *metric,
+                  mcpl_particle_t *part, double bw, char kernel) {
   double x = part->position[0], y = part->position[1], z = part->position[2];
   double dx = part->direction[0], dy = part->direction[1],
          dz = part->direction[2], dx2, dz2;
@@ -404,14 +407,14 @@ int Guide_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
     break;
   }
   // Perturb
-  z += bw * metric->scaling[0] * rand_type(kernel);
+  z += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
   while ((z < 0) || (z > zmax)) {
     if (z < 0)
       z *= -1;
     else
       z -= 2 * (z - zmax);
   }
-  t += bw * metric->scaling[1] * rand_type(kernel);
+  t += bw * metric->scaling[1] * kds_rand_type(rng, kernel);
   switch (mirror) { // Avoid perturbation to change mirror
   case 0:
     while ((t < 0) || (t > yheight)) {
@@ -447,9 +450,9 @@ int Guide_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
     break;
   }
   if (isinf(metric->scaling[2]))
-    mu = -1 + 2. * rand() / RAND_MAX;
+    mu = -1 + 2. * rng();
   else {
-    mu2 = mu + bw * metric->scaling[2] * rand_type(kernel);
+    mu2 = mu + bw * metric->scaling[2] * kds_rand_type(rng, kernel);
     if (mu >= 0) {
       while ((mu2 < 0) || (mu2 > 1)) {
         if (mu2 < 0)
@@ -468,9 +471,9 @@ int Guide_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
     mu = mu2;
   }
   if (isinf(metric->scaling[3]))
-    phi = 2. * KDS_PI * rand() / RAND_MAX;
+    phi = 2. * KDS_PI * rng();
   else
-    phi += bw * metric->scaling[3] * KDS_PI / 180 * rand_type(kernel);
+    phi += bw * metric->scaling[3] * KDS_PI / 180 * kds_rand_type(rng, kernel);
   // Antitransform from (z,t,theta_n,theta_t) to (x,y,z,dx,dy,dz)
   switch (mirror) {
   case 0:
@@ -520,11 +523,12 @@ int Guide_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
   return 0;
 }
 
-void _vMF_perturb(double bw, double *dx, double *dy, double *dz) {
-  double xi = (double)rand() / RAND_MAX;
+void _vMF_perturb(kds_rng_fct_t rng, double bw, double *dx, double *dy,
+                  double *dz) {
+  double xi = rng();
   double w = 1;
   w += bw * bw * log(xi + (1 - xi) * exp(-2 / (bw * bw)));
-  double phi = 2. * KDS_PI * rand() / RAND_MAX;
+  double phi = 2. * KDS_PI * rng();
   double uv = sqrt(1 - w * w), u = uv * cos(phi), v = uv * sin(phi);
   double dx0 = *dx, dy0 = *dy, dz0 = *dz;
   if (dz0 > 0) {
@@ -537,19 +541,19 @@ void _vMF_perturb(double bw, double *dx, double *dy, double *dz) {
   *dz = w * dz0 - u * dx0 - v * dy0;
 }
 
-int Isotrop_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                    char kernel) {
+int Isotrop_perturb(kds_rng_fct_t rng, const Metric *metric,
+                    mcpl_particle_t *part, double bw, char kernel) {
   if (isinf(bw * metric->scaling[0])) { // Generate isotropic direction
-    part->direction[2] = -1 + 2. * rand() / RAND_MAX;
+    part->direction[2] = -1 + 2. * rng();
     double dxy = sqrt(1 - part->direction[2] * part->direction[2]);
-    double phi = 2. * KDS_PI * rand() / RAND_MAX;
+    double phi = 2. * KDS_PI * rng();
     part->direction[0] = dxy * cos(phi);
     part->direction[1] = dxy * sin(phi);
   } else if (bw * metric->scaling[0] >
              0) { // Perturb following von Mises-Fischer distribution
     double dx = part->direction[0], dy = part->direction[1],
            dz = part->direction[2];
-    _vMF_perturb(bw * metric->scaling[0], &part->direction[0],
+    _vMF_perturb(rng, bw * metric->scaling[0], &part->direction[0],
                  &part->direction[1], &part->direction[2]);
     int keepx = (int)metric->params[0], keepy = (int)metric->params[1],
         keepz = (int)metric->params[2];
@@ -563,30 +567,31 @@ int Isotrop_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
   return 0;
 }
 
-int Polar_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                  char kernel) {
+int Polar_perturb(kds_rng_fct_t rng, const Metric *metric,
+                  mcpl_particle_t *part, double bw, char kernel) {
   double theta, theta2, phi;
   // int cont = 0;
   theta = acos(part->direction[2]);
   phi = atan2(part->direction[1], part->direction[0]);
-  theta2 = theta + bw * metric->scaling[0] * KDS_PI / 180 * rand_type(kernel);
+  theta2 = theta +
+           bw * metric->scaling[0] * KDS_PI / 180 * kds_rand_type(rng, kernel);
   if (cos(theta2) * cos(theta) < 0)
     theta += 2 * (KDS_PI / 2 - theta);
   theta = theta2;
-  phi += bw * metric->scaling[1] * KDS_PI / 180 * rand_type(kernel);
+  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
   part->direction[0] = sin(theta) * cos(phi);
   part->direction[1] = sin(theta) * sin(phi);
   part->direction[2] = cos(theta);
   return 0;
 }
 
-int PolarMu_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
-                    char kernel) {
+int PolarMu_perturb(kds_rng_fct_t rng, const Metric *metric,
+                    mcpl_particle_t *part, double bw, char kernel) {
   double mu, mu2, phi;
   // int cont = 0;
   mu = part->direction[2];
   phi = atan2(part->direction[1], part->direction[0]);
-  mu2 = mu + bw * metric->scaling[0] * rand_type(kernel);
+  mu2 = mu + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
   if (mu >= 0) {
     while ((mu2 < 0) || (mu2 > 1)) {
       if (mu2 < 0)
@@ -603,7 +608,7 @@ int PolarMu_perturb(const Metric *metric, mcpl_particle_t *part, double bw,
     }
   }
   mu = mu2;
-  phi += bw * metric->scaling[1] * KDS_PI / 180 * rand_type(kernel);
+  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
   part->direction[0] = sqrt(1 - mu * mu) * cos(phi);
   part->direction[1] = sqrt(1 - mu * mu) * sin(phi);
   part->direction[2] = mu;

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -8,18 +8,17 @@
 
 #define KDS_PI 3.1415926535897932384626433832795028841971694
 
-//Implement constants defined extern in header:
+// Implement constants defined extern in header:
 const int _n_metrics = 14;
-const char *_metric_names[] = {
-  "Energy", "Lethargy", "Wavelength", "Vol",   "SurfXY",
-  "SurfR",  "SurfR2",   "SurfCircle", "Guide", "Isotrop",
-  "Polar",  "PolarMu",  "Time",       "Decade"};
+const char *_metric_names[] = {"Energy", "Lethargy", "Wavelength", "Vol",
+                               "SurfXY", "SurfR",    "SurfR2",     "SurfCircle",
+                               "Guide",  "Isotrop",  "Polar",      "PolarMu",
+                               "Time",   "Decade"};
 const PerturbFun _metric_perturbs[] = {
-  E_perturb,      Let_perturb,     wl_perturb,     Vol_perturb,
-  SurfXY_perturb, SurfR_perturb,   SurfR2_perturb, SurfCircle_perturb,
-  Guide_perturb,  Isotrop_perturb, Polar_perturb,  PolarMu_perturb,
-  t_perturb,      Dec_perturb};
-
+    E_perturb,      Let_perturb,     wl_perturb,     Vol_perturb,
+    SurfXY_perturb, SurfR_perturb,   SurfR2_perturb, SurfCircle_perturb,
+    Guide_perturb,  Isotrop_perturb, Polar_perturb,  PolarMu_perturb,
+    t_perturb,      Dec_perturb};
 
 void KDS_error(const char *msg);
 void KDS_end(const char *msg);
@@ -560,7 +559,7 @@ void _vMF_perturb(kds_rng_fct_t rng, double bw, double *dx, double *dy,
 
 int Isotrop_perturb(kds_rng_fct_t rng, const Metric *metric,
                     mcpl_particle_t *part, double bw, char kernel) {
-  (void)kernel;//unused
+  (void)kernel;                         // unused
   if (isinf(bw * metric->scaling[0])) { // Generate isotropic direction
     part->direction[2] = -1 + 2. * rng();
     double dxy = sqrt(1 - part->direction[2] * part->direction[2]);

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -11,15 +11,15 @@
 void KDS_error(const char *msg);
 void KDS_end(const char *msg);
 
+void *KDS_malloc(size_t);
+void *KDS_calloc_i(int n_elem, size_t elem_size);
+
 Metric *Metric_create(int dim, const double *scaling, PerturbFun perturb,
                       int nps, const double *params) {
-  Metric *metric = (Metric *)malloc(sizeof(Metric));
+  Metric *metric = (Metric *)KDS_malloc(sizeof(Metric));
   int i;
-  if (dim < 1)
-    KDS_error("Error in Metric_create: invalid value of \"dim\"");
-  const unsigned udim = (unsigned)(dim);
   metric->dim = dim;
-  metric->scaling = (float *)malloc(udim * sizeof(float));
+  metric->scaling = (float *)KDS_calloc_i(dim, sizeof(float));
   if (scaling)
     for (i = 0; i < dim; i++)
       metric->scaling[i] = (float)scaling[i];
@@ -28,29 +28,20 @@ Metric *Metric_create(int dim, const double *scaling, PerturbFun perturb,
       metric->scaling[i] = 0;
   metric->perturb = perturb;
   metric->nps = nps;
-  if (nps < 1)
-    KDS_error("Error in Metric_create: invalid value of \"nps\"");
-  const unsigned unps = (unsigned)(nps);
-  metric->params = (double *)malloc(unps * sizeof(double));
+  metric->params = (double *)KDS_calloc_i(nps, sizeof(double));
   for (i = 0; i < nps; i++)
     metric->params[i] = params[i];
   return metric;
 }
 
 Metric *Metric_copy(const Metric *from) {
-  Metric *metric = (Metric *)malloc(sizeof(Metric));
+  Metric *metric = (Metric *)KDS_malloc(sizeof(Metric));
   *metric = *from;
   int i;
-  if (metric->dim < 1)
-    KDS_error("Error in Metric_copy: invalid value of \"metrid->dim\"");
-  const unsigned udim = (unsigned)(metric->dim);
-  metric->scaling = (float *)malloc(udim * sizeof(double));
+  metric->scaling = (float *)KDS_calloc_i(metric->dim, sizeof(double));
   for (i = 0; i < metric->dim; i++)
     metric->scaling[i] = from->scaling[i];
-  if (metric->nps < 1)
-    KDS_error("Error in Metric_copy: invalid value of \"metrid->nps\"");
-  const unsigned unps = (unsigned)(metric->nps);
-  metric->params = (double *)malloc(unps * sizeof(double));
+  metric->params = (double *)KDS_calloc_i(metric->nps, sizeof(double));
   for (i = 0; i < metric->nps; i++)
     metric->params[i] = from->params[i];
   return metric;
@@ -64,13 +55,10 @@ void Metric_destroy(Metric *metric) {
 Geometry *Geom_create(int ord, Metric **metrics, double bw,
                       const char *bwfilename, char kernel, const double *trasl,
                       const double *rot) {
-  if (ord < 1)
-    KDS_error("Error in Geom_create: invalid value of \"ord\"");
-  const unsigned uord = (unsigned)(ord);
-  Geometry *geom = (Geometry *)malloc(sizeof(Geometry));
+  Geometry *geom = (Geometry *)KDS_malloc(sizeof(Geometry));
   geom->ord = ord;
   int i;
-  geom->ms = (Metric **)malloc(uord * sizeof(Metric *));
+  geom->ms = (Metric **)KDS_calloc_i(ord, sizeof(Metric *));
   for (i = 0; i < ord; i++)
     geom->ms[i] = metrics[i];
   geom->bw = bw;
@@ -84,19 +72,19 @@ Geometry *Geom_create(int ord, Metric **metrics, double bw,
         printf("Could not open file %s\n", bwfilename);
         KDS_error("Error in Geom_create");
       }
-      geom->bwfilename = (char *)malloc(NAME_MAX_LEN * sizeof(char));
+      geom->bwfilename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
       strcpy(geom->bwfilename, bwfilename);
       geom->bwfile = bwfile;
       Geom_next(geom, 1);
     }
   if (trasl) {
-    geom->trasl = (double *)malloc(3 * sizeof(double));
+    geom->trasl = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       geom->trasl[i] = trasl[i];
   } else
     geom->trasl = NULL;
   if (rot) {
-    geom->rot = (double *)malloc(3 * sizeof(double));
+    geom->rot = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       geom->rot[i] = rot[i];
   } else
@@ -105,33 +93,29 @@ Geometry *Geom_create(int ord, Metric **metrics, double bw,
 }
 
 Geometry *Geom_copy(const Geometry *from) {
-  Geometry *geom = (Geometry *)malloc(sizeof(Geometry));
+  Geometry *geom = (Geometry *)KDS_malloc(sizeof(Geometry));
   *geom = *from;
   int i;
 
-  if (geom->ord < 1)
-    KDS_error("Error in Geom_copy: invalid value of \"geom->ord\"");
-  const unsigned uord = (unsigned)(geom->ord);
-
-  geom->ms = (Metric **)malloc(uord * sizeof(Metric *));
+  geom->ms = (Metric **)KDS_calloc_i(geom->ord, sizeof(Metric *));
   for (i = 0; i < geom->ord; i++)
     geom->ms[i] = Metric_copy(from->ms[i]);
   geom->bwfilename = NULL;
   geom->bwfile = NULL;
   if (geom->bwfile) {
-    geom->bwfilename = (char *)malloc(NAME_MAX_LEN * sizeof(char));
+    geom->bwfilename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
     strcpy(geom->bwfilename, from->bwfilename);
     geom->bwfile = fopen(geom->bwfilename, "rb");
     Geom_next(geom, 1);
   }
   if (from->trasl) {
-    geom->trasl = (double *)malloc(3 * sizeof(double));
+    geom->trasl = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       geom->trasl[i] = from->trasl[i];
   } else
     geom->trasl = NULL;
   if (from->rot) {
-    geom->rot = (double *)malloc(3 * sizeof(double));
+    geom->rot = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       geom->rot[i] = from->rot[i];
   } else

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -8,6 +8,19 @@
 
 #define KDS_PI 3.1415926535897932384626433832795028841971694
 
+//Implement constants defined extern in header:
+const int _n_metrics = 14;
+const char *_metric_names[] = {
+  "Energy", "Lethargy", "Wavelength", "Vol",   "SurfXY",
+  "SurfR",  "SurfR2",   "SurfCircle", "Guide", "Isotrop",
+  "Polar",  "PolarMu",  "Time",       "Decade"};
+const PerturbFun _metric_perturbs[] = {
+  E_perturb,      Let_perturb,     wl_perturb,     Vol_perturb,
+  SurfXY_perturb, SurfR_perturb,   SurfR2_perturb, SurfCircle_perturb,
+  Guide_perturb,  Isotrop_perturb, Polar_perturb,  PolarMu_perturb,
+  t_perturb,      Dec_perturb};
+
+
 void KDS_error(const char *msg);
 void KDS_end(const char *msg);
 
@@ -547,6 +560,7 @@ void _vMF_perturb(kds_rng_fct_t rng, double bw, double *dx, double *dy,
 
 int Isotrop_perturb(kds_rng_fct_t rng, const Metric *metric,
                     mcpl_particle_t *part, double bw, char kernel) {
+  (void)kernel;//unused
   if (isinf(bw * metric->scaling[0])) { // Generate isotropic direction
     part->direction[2] = -1 + 2. * rng();
     double dxy = sqrt(1 - part->direction[2] * part->direction[2]);

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -15,8 +15,11 @@ Metric *Metric_create(int dim, const double *scaling, PerturbFun perturb,
                       int nps, const double *params) {
   Metric *metric = (Metric *)malloc(sizeof(Metric));
   int i;
+  if (dim < 1)
+    KDS_error("Error in Metric_create: invalid value of \"dim\"");
+  const unsigned udim = (unsigned)(dim);
   metric->dim = dim;
-  metric->scaling = (float *)malloc(dim * sizeof(float));
+  metric->scaling = (float *)malloc(udim * sizeof(float));
   if (scaling)
     for (i = 0; i < dim; i++)
       metric->scaling[i] = (float)scaling[i];
@@ -25,7 +28,10 @@ Metric *Metric_create(int dim, const double *scaling, PerturbFun perturb,
       metric->scaling[i] = 0;
   metric->perturb = perturb;
   metric->nps = nps;
-  metric->params = (double *)malloc(nps * sizeof(double));
+  if (nps < 1)
+    KDS_error("Error in Metric_create: invalid value of \"nps\"");
+  const unsigned unps = (unsigned)(nps);
+  metric->params = (double *)malloc(unps * sizeof(double));
   for (i = 0; i < nps; i++)
     metric->params[i] = params[i];
   return metric;
@@ -35,10 +41,16 @@ Metric *Metric_copy(const Metric *from) {
   Metric *metric = (Metric *)malloc(sizeof(Metric));
   *metric = *from;
   int i;
-  metric->scaling = (float *)malloc(metric->dim * sizeof(double));
+  if (metric->dim < 1)
+    KDS_error("Error in Metric_copy: invalid value of \"metrid->dim\"");
+  const unsigned udim = (unsigned)(metric->dim);
+  metric->scaling = (float *)malloc(udim * sizeof(double));
   for (i = 0; i < metric->dim; i++)
     metric->scaling[i] = from->scaling[i];
-  metric->params = (double *)malloc(metric->nps * sizeof(double));
+  if (metric->nps < 1)
+    KDS_error("Error in Metric_copy: invalid value of \"metrid->nps\"");
+  const unsigned unps = (unsigned)(metric->nps);
+  metric->params = (double *)malloc(unps * sizeof(double));
   for (i = 0; i < metric->nps; i++)
     metric->params[i] = from->params[i];
   return metric;
@@ -52,10 +64,13 @@ void Metric_destroy(Metric *metric) {
 Geometry *Geom_create(int ord, Metric **metrics, double bw,
                       const char *bwfilename, char kernel, const double *trasl,
                       const double *rot) {
+  if (ord < 1)
+    KDS_error("Error in Geom_create: invalid value of \"ord\"");
+  const unsigned uord = (unsigned)(ord);
   Geometry *geom = (Geometry *)malloc(sizeof(Geometry));
   geom->ord = ord;
   int i;
-  geom->ms = (Metric **)malloc(ord * sizeof(Metric *));
+  geom->ms = (Metric **)malloc(uord * sizeof(Metric *));
   for (i = 0; i < ord; i++)
     geom->ms[i] = metrics[i];
   geom->bw = bw;
@@ -93,7 +108,12 @@ Geometry *Geom_copy(const Geometry *from) {
   Geometry *geom = (Geometry *)malloc(sizeof(Geometry));
   *geom = *from;
   int i;
-  geom->ms = (Metric **)malloc(geom->ord * sizeof(Metric *));
+
+  if (geom->ord < 1)
+    KDS_error("Error in Geom_copy: invalid value of \"geom->ord\"");
+  const unsigned uord = (unsigned)(geom->ord);
+
+  geom->ms = (Metric **)malloc(uord * sizeof(Metric *));
   for (i = 0; i < geom->ord; i++)
     geom->ms[i] = Metric_copy(from->ms[i]);
   geom->bwfilename = NULL;

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -25,6 +25,7 @@ void KDS_end(const char *msg);
 
 void *KDS_malloc(size_t);
 void *KDS_calloc_i(int n_elem, size_t elem_size);
+void KDS_strcpyname(char *dst, const char *src);
 
 Metric *Metric_create(int dim, const double *scaling, PerturbFun perturb,
                       int nps, const double *params) {
@@ -85,7 +86,7 @@ Geometry *Geom_create(int ord, Metric **metrics, double bw,
         KDS_error("Error in Geom_create");
       }
       geom->bwfilename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
-      strcpy(geom->bwfilename, bwfilename);
+      KDS_strcpyname(geom->bwfilename, bwfilename);
       geom->bwfile = bwfile;
       Geom_next(geom, 1);
     }
@@ -116,7 +117,7 @@ Geometry *Geom_copy(const Geometry *from) {
   geom->bwfile = NULL;
   if (geom->bwfile) {
     geom->bwfilename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
-    strcpy(geom->bwfilename, from->bwfilename);
+    KDS_strcpyname(geom->bwfilename, from->bwfilename);
     geom->bwfile = fopen(geom->bwfilename, "rb");
     Geom_next(geom, 1);
   }

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -380,7 +380,10 @@ int Guide_perturb(kds_rng_fct_t rng, const Metric *metric,
          dz = part->direction[2], dx2, dz2;
   double xwidth = metric->params[0], yheight = metric->params[1],
          zmax = metric->params[2], rcurv = metric->params[3];
-  double t, mu, mu2, phi;
+  double t = 0.0;
+  double mu = 0.0;
+  double mu2 = 0.0;
+  double phi = 0.0;
   // int cont = 0;
   int mirror;
   if (rcurv != 0) { // Transform to curved guide variables

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -44,6 +44,28 @@ void KDS_end(const char *msg) {
   exit(EXIT_SUCCESS);
 }
 
+void KDS_strcpy(char *dst, size_t dst_buflen, const char *src) {
+  // Safe + portable + C99 compatible implementation of strcpy
+  if (!dst || !src || !dst_buflen) {
+    KDS_error("invalid strcpy (null arg)");
+    return;
+  }
+  size_t srclen = 0;
+  while (srclen < dst_buflen && src[srclen])
+    ++srclen;
+  if (!(srclen < dst_buflen)) {
+    KDS_error("invalid strcpy (too small buffer)");
+    return;
+  }
+  if (srclen > 1)
+    memcpy(dst, src, srclen);
+  dst[srclen] = 0;
+}
+
+void KDS_strcpyname(char *dst, const char *src) {
+  KDS_strcpy(dst, NAME_MAX_LEN, src);
+}
+
 KDSource *KDS_create(double J, char kernel, PList *plist, Geometry *geom) {
   KDSource *kds = (KDSource *)KDS_malloc(sizeof(KDSource));
   kds->J = J;
@@ -103,8 +125,9 @@ KDSource *KDS_open(const char *xmlfilename) {
            (char *)xmlNodeGetContent(node), NAME_MAX_LEN);
     KDS_error("Error in KDS_open");
   }
-  strcpy(mcplfile, (char *)xmlNodeGetContent(node)); // Read mcpl file name
-  node = node->next;                                 // Node: trasl
+  KDS_strcpyname(mcplfile,
+                 (char *)xmlNodeGetContent(node)); // Read mcpl file name
+  node = node->next;                               // Node: trasl
   if (strlen((char *)xmlNodeGetContent(node)) > 1) {
     trasl_plist = (double *)KDS_malloc(3 * sizeof(double));
     sscanf((char *)xmlNodeGetContent(node), "%lf %lf %lf", &trasl_plist[0],
@@ -151,7 +174,7 @@ KDSource *KDS_open(const char *xmlfilename) {
 
   xmlNodePtr mtree = gtree->children;
   for (i = 0; i < order; i++) {
-    strcpy(metricnames[i], (char *)mtree->name);             // Read metricname
+    KDS_strcpyname(metricnames[i], (char *)mtree->name);     // Read metricname
     node = mtree->children;                                  // Node: dim
     sscanf((char *)xmlNodeGetContent(node), "%d", &dims[i]); // Read dim
 
@@ -199,7 +222,8 @@ KDSource *KDS_open(const char *xmlfilename) {
              (char *)xmlNodeGetContent(node), NAME_MAX_LEN);
       KDS_error("Error in KDS_open");
     }
-    strcpy(bwfilename, (char *)xmlNodeGetContent(node)); // Read BW file name
+    KDS_strcpyname(bwfilename,
+                   (char *)xmlNodeGetContent(node)); // Read BW file name
   } else
     sscanf((char *)xmlNodeGetContent(node), "%lf", &bw); // Read BW
 

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -168,9 +168,11 @@ KDSource *KDS_open(const char *xmlfilename) {
     free(metricnames);
     free(perturbs);
     free(metrics);
+    dims = NULL;
     KDS_error("Error in KDS_open: memory allocation failure");
-    return NULL;
   }
+  if (!dims)
+    return NULL;
 
   xmlNodePtr mtree = gtree->children;
   for (i = 0; i < order; i++) {
@@ -395,9 +397,11 @@ MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws) {
     KDS_error("Error in MS_open: invalid value of \"len\"");
   KDSource **s = KDS_calloc_i(len, sizeof(KDSource *));
   if (!s) {
+    len = 0;
     KDS_error("Error in MS_open: memory allocation failure");
-    return NULL;
   }
+  if (len == 0)
+    return NULL;
   int i;
   for (i = 0; i < len; i++)
     s[i] = KDS_open(xmlfilenames[i]);

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -298,12 +298,17 @@ int KDS_sample(KDSource *kds, mcpl_particle_t *part) {
 }
 
 double KDS_w_mean(KDSource *kds, int N, WeightFun bias) {
+  kds_rng_fct_t rng = KDS_default_rngfct;
+  return KDS_rand_w_mean(rng,kds,N,bias);
+}
+
+double KDS_rand_w_mean(kds_rng_fct_t rng, KDSource *kds, int N, WeightFun bias) {
   int i;
   //char pt;
   mcpl_particle_t part;
   double w_mean = 0;
   for (i = 0; i < N; i++) {
-    KDS_sample2(kds, &part, 0, -1, NULL, 1);
+    KDS_rand_sample2(rng,kds, &part, 0, -1, NULL, 1);
     if (bias)
       w_mean += part.weight * bias(&part);
     else
@@ -368,7 +373,7 @@ int MS_rand_sample2(kds_rng_fct_t rng, MultiSource *ms, mcpl_particle_t *part,
   else
     for (i = 0; y * ms->cdf[ms->len - 1] > ms->cdf[i]; i++)
       ;
-  ret = KDS_sample2(ms->s[i], part, perturb, w_crit, bias, loop);
+  ret = KDS_rand_sample2(rng,ms->s[i], part, perturb, w_crit, bias, loop);
   if (ms->cdf[ms->len - 1] > 0)
     part->weight *= (ms->s[i]->J / ms->J) / (ms->ws[i] / ms->cdf[ms->len - 1]);
   else
@@ -392,10 +397,16 @@ int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
 }
 
 double MS_w_mean(MultiSource *ms, int N, WeightFun bias) {
+  kds_rng_fct_t rng = KDS_default_rngfct;
+  return MS_rand_w_mean(rng,ms,N,bias);
+}
+
+double MS_rand_w_mean(kds_rng_fct_t rng,
+                      MultiSource *ms, int N, WeightFun bias) {
   double w_mean = 0;
   int i;
   for (i = 0; i < ms->len; i++)
-    w_mean += ms->ws[i] * KDS_w_mean(ms->s[i], N, bias);
+    w_mean += ms->ws[i] * KDS_rand_w_mean(rng,ms->s[i], N, bias);
   return w_mean / ms->cdf[ms->len - 1];
 }
 

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -7,6 +7,11 @@
 
 #include "kdsource/kdsource.h"
 
+double KDS_default_rngfct(void) {
+  // This is a horrible RNG:
+  return rand() / (RAND_MAX + 1.0);
+}
+
 void KDS_error(const char *msg) {
   printf("KDSource error: %s\n", msg);
   exit(EXIT_FAILURE);
@@ -220,13 +225,13 @@ KDSource *KDS_open(const char *xmlfilename) {
   return s;
 }
 
-int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
-                double w_crit, WeightFun bias, int loop) {
+int KDS_rand_sample2(kds_rng_fct_t rng, KDSource *kds, mcpl_particle_t *part,
+                     int perturb, double w_crit, WeightFun bias, int loop) {
   int ret = 0;
   if (w_crit <= 0) {
     PList_get(kds->plist, part);
     if (perturb)
-      Geom_perturb(kds->geom, part);
+      Geom_perturb(rng, kds->geom, part);
     ret += PList_next(kds->plist, loop);
     ret += Geom_next(kds->geom, loop);
   } else { // Normalize w to 1
@@ -241,18 +246,18 @@ int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
       if (part->weight * bs > w_crit) { // If w*bs>w_crit, use w_crit/w*bs as
                                         // prob of going forward in list
         if (perturb)
-          Geom_perturb(kds->geom, part);
-        if (rand() < w_crit / (part->weight * bs) * RAND_MAX) {
+          Geom_perturb(rng, kds->geom, part);
+        if (rng() < w_crit / (part->weight * bs)) {
           ret += PList_next(kds->plist, loop);
           ret += Geom_next(kds->geom, loop);
         }
         break;
       } else { // If w*bs<w_crit, use w*bs/w_crit as prob of taking particle
         int take = 0;
-        if (rand() < (part->weight * bs) / w_crit * RAND_MAX) {
+        if (rng() < (part->weight * bs) / w_crit) {
           take = 1;
           if (perturb)
-            Geom_perturb(kds->geom, part);
+            Geom_perturb(rng, kds->geom, part);
         }
         ret += PList_next(kds->plist, loop);
         ret += Geom_next(kds->geom, loop);
@@ -269,8 +274,19 @@ int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
   return ret;
 }
 
+int KDS_rand_sample(kds_rng_fct_t rng, KDSource *kds, mcpl_particle_t *part) {
+  return KDS_rand_sample2(rng, kds, part, 1, 1, NULL, 1);
+}
+
+int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
+                double w_crit, WeightFun bias, int loop) {
+  kds_rng_fct_t rng = KDS_default_rngfct;
+  return KDS_rand_sample2(rng, kds, part, perturb, w_crit, bias, loop);
+}
+
 int KDS_sample(KDSource *kds, mcpl_particle_t *part) {
-  return KDS_sample2(kds, part, 1, 1, NULL, 1);
+  kds_rng_fct_t rng = KDS_default_rngfct;
+  return KDS_rand_sample(rng, kds, part);
 }
 
 double KDS_w_mean(KDSource *kds, int N, WeightFun bias) {
@@ -330,9 +346,9 @@ MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws) {
   return result;
 }
 
-int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
-               double w_crit, WeightFun bias, int loop) {
-  double y = rand() / ((double)RAND_MAX + 1);
+int MS_rand_sample2(kds_rng_fct_t rng, MultiSource *ms, mcpl_particle_t *part,
+                    int perturb, double w_crit, WeightFun bias, int loop) {
+  double y = rng();
   int i, ret;
   if (ms->cdf[ms->len - 1] <= 0)
     i = (int)(y * ms->len);
@@ -347,8 +363,19 @@ int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
   return ret;
 }
 
+int MS_rand_sample(kds_rng_fct_t rng, MultiSource *ms, mcpl_particle_t *part) {
+  return MS_rand_sample2(rng, ms, part, 1, 1, NULL, 1);
+}
+
 int MS_sample(MultiSource *ms, mcpl_particle_t *part) {
-  return MS_sample2(ms, part, 1, 1, NULL, 1);
+  kds_rng_fct_t rng = KDS_default_rngfct;
+  return MS_rand_sample(rng, ms, part);
+}
+
+int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
+               double w_crit, WeightFun bias, int loop) {
+  kds_rng_fct_t rng = KDS_default_rngfct;
+  return MS_rand_sample2(rng, ms, part, perturb, w_crit, bias, loop);
 }
 
 double MS_w_mean(MultiSource *ms, int N, WeightFun bias) {

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -7,22 +7,45 @@
 
 #include "kdsource/kdsource.h"
 
+void KDS_error(const char *msg) {
+  printf("KDSource error: %s\n", msg);
+  exit(EXIT_FAILURE);
+}
+
+void *KDS_malloc(size_t n_bytes) {
+  void *a = malloc(n_bytes ? n_bytes : 1);
+  if (!a)
+    KDS_error("memory allocation failed");
+  return a;
+}
+
+void *KDS_calloc(size_t n_elem, size_t elem_size) {
+  if (elem_size == 0)
+    KDS_error("trying to allocate space for elements of size 0");
+  void *a = calloc(n_elem, elem_size);
+  if (!a)
+    KDS_error("memory allocation failed");
+  return a;
+}
+
+void *KDS_calloc_i(int n_elem, size_t elem_size) {
+  if (n_elem < 0)
+    KDS_error("trying to allocate space for negative number of elements");
+  return KDS_calloc((size_t)(n_elem), elem_size);
+}
+
 double KDS_default_rngfct(void) {
   // This is a horrible RNG:
   return rand() / (RAND_MAX + 1.0);
 }
 
-void KDS_error(const char *msg) {
-  printf("KDSource error: %s\n", msg);
-  exit(EXIT_FAILURE);
-}
 void KDS_end(const char *msg) {
   printf("KDSource terminate: %s\n", msg);
   exit(EXIT_SUCCESS);
 }
 
 KDSource *KDS_create(double J, char kernel, PList *plist, Geometry *geom) {
-  KDSource *kds = (KDSource *)malloc(sizeof(KDSource));
+  KDSource *kds = (KDSource *)KDS_malloc(sizeof(KDSource));
   kds->J = J;
   kds->kernel = kernel;
   kds->plist = plist;
@@ -83,13 +106,13 @@ KDSource *KDS_open(const char *xmlfilename) {
   strcpy(mcplfile, (char *)xmlNodeGetContent(node)); // Read mcpl file name
   node = node->next;                                 // Node: trasl
   if (strlen((char *)xmlNodeGetContent(node)) > 1) {
-    trasl_plist = (double *)malloc(3 * sizeof(double));
+    trasl_plist = (double *)KDS_malloc(3 * sizeof(double));
     sscanf((char *)xmlNodeGetContent(node), "%lf %lf %lf", &trasl_plist[0],
            &trasl_plist[1], &trasl_plist[2]);
   }
   node = node->next; // Node: rot
   if (strlen((char *)xmlNodeGetContent(node)) > 1) {
-    rot_plist = (double *)malloc(3 * sizeof(double));
+    rot_plist = (double *)KDS_malloc(3 * sizeof(double));
     sscanf((char *)xmlNodeGetContent(node), "%lf %lf %lf", &rot_plist[0],
            &rot_plist[1], &rot_plist[2]);
   }
@@ -102,16 +125,16 @@ KDSource *KDS_open(const char *xmlfilename) {
          &order); // Read order
   if (order < 1)
     KDS_error("Error in KDS_open: invalid value of \"order\"");
-  const unsigned uorder = (unsigned)(order);
+  const size_t uorder = (unsigned)(order);
 
-  int *dims = malloc(sizeof(int) * uorder);
-  int *nps = malloc(sizeof(int) * uorder);
-  double **params = malloc(sizeof(double *) * uorder);
-  double **scalings = malloc(sizeof(double *) * uorder);
+  int *dims = KDS_calloc(uorder, sizeof(int));
+  int *nps = KDS_calloc(uorder, sizeof(int));
+  double **params = KDS_calloc(uorder, sizeof(double *));
+  double **scalings = KDS_calloc(uorder, sizeof(double *));
   char(*metricnames)[NAME_MAX_LEN] =
-      malloc(sizeof(char) * NAME_MAX_LEN * uorder);
-  PerturbFun *perturbs = malloc(sizeof(PerturbFun) * uorder);
-  Metric **metrics = malloc(sizeof(Metric *) * uorder);
+      KDS_calloc(uorder, NAME_MAX_LEN * sizeof(char));
+  PerturbFun *perturbs = KDS_calloc(uorder, sizeof(PerturbFun));
+  Metric **metrics = KDS_calloc(uorder, sizeof(Metric *));
 
   if (!dims || !nps || !params || !scalings || !perturbs || !metricnames ||
       !metrics) {
@@ -134,15 +157,11 @@ KDSource *KDS_open(const char *xmlfilename) {
 
     if (dims[i] < 1)
       KDS_error("Error in KDS_open: invalid value of \"dims[i]\"");
-    const unsigned udimsi = (unsigned)(dims[i]);
-    scalings[i] = (double *)malloc(udimsi * sizeof(double));
+    scalings[i] = (double *)KDS_calloc_i(dims[i], sizeof(double));
     node = node->next; // Node: params
     sscanf((char *)xmlGetProp(node, (const xmlChar *)"nps"), "%d",
            &nps[i]); // Read ngp
-    if (nps[i] < 1)
-      KDS_error("Error in KDS_open: invalid value of \"nps[i]\"");
-    const unsigned unpsi = (unsigned)(nps[i]);
-    params[i] = (double *)malloc(unpsi * sizeof(double));
+    params[i] = (double *)KDS_calloc_i(nps[i], sizeof(double));
     buf = (char *)xmlNodeGetContent(node);
     for (j = 0; j < nps[i]; j++) { // Read params
       sscanf(buf, "%lf %n", &params[i][j], &n);
@@ -152,13 +171,13 @@ KDSource *KDS_open(const char *xmlfilename) {
   }
   node = mtree; // Node: trasl
   if (strlen((char *)xmlNodeGetContent(node)) > 1) {
-    trasl_geom = (double *)malloc(3 * sizeof(double));
+    trasl_geom = (double *)KDS_malloc(3 * sizeof(double));
     sscanf((char *)xmlNodeGetContent(node), "%lf %lf %lf", &trasl_geom[0],
            &trasl_geom[1], &trasl_geom[2]);
   }
   node = node->next; // Node: rot
   if (strlen((char *)xmlNodeGetContent(node)) > 1) {
-    rot_geom = (double *)malloc(3 * sizeof(double));
+    rot_geom = (double *)KDS_malloc(3 * sizeof(double));
     sscanf((char *)xmlNodeGetContent(node), "%lf %lf %lf", &rot_geom[0],
            &rot_geom[1], &rot_geom[2]);
   }
@@ -174,7 +193,7 @@ KDSource *KDS_open(const char *xmlfilename) {
   sscanf((char *)xmlGetProp(node, (const xmlChar *)"variable"), "%d",
          &variable_bw); // Read variable_bw
   if (variable_bw) {
-    bwfilename = (char *)malloc(NAME_MAX_LEN * sizeof(char));
+    bwfilename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
     if (strlen((char *)xmlNodeGetContent(node)) > NAME_MAX_LEN) {
       printf("BW file name %s exceeds NAME_MAX_LEN=%d",
              (char *)xmlNodeGetContent(node), NAME_MAX_LEN);
@@ -299,16 +318,17 @@ int KDS_sample(KDSource *kds, mcpl_particle_t *part) {
 
 double KDS_w_mean(KDSource *kds, int N, WeightFun bias) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return KDS_rand_w_mean(rng,kds,N,bias);
+  return KDS_rand_w_mean(rng, kds, N, bias);
 }
 
-double KDS_rand_w_mean(kds_rng_fct_t rng, KDSource *kds, int N, WeightFun bias) {
+double KDS_rand_w_mean(kds_rng_fct_t rng, KDSource *kds, int N,
+                       WeightFun bias) {
   int i;
-  //char pt;
+  // char pt;
   mcpl_particle_t part;
   double w_mean = 0;
   for (i = 0; i < N; i++) {
-    KDS_rand_sample2(rng,kds, &part, 0, -1, NULL, 1);
+    KDS_rand_sample2(rng, kds, &part, 0, -1, NULL, 1);
     if (bias)
       w_mean += part.weight * bias(&part);
     else
@@ -324,14 +344,13 @@ void KDS_destroy(KDSource *kds) {
 }
 
 MultiSource *MS_create(int len, KDSource **s, const double *ws) {
-  MultiSource *ms = (MultiSource *)malloc(sizeof(MultiSource));
+  MultiSource *ms = (MultiSource *)KDS_malloc(sizeof(MultiSource));
 
   if (len < 1)
     KDS_error("Error in MS_create: invalid value of \"len\"");
-  const unsigned ulen = (unsigned)(len);
   ms->len = len;
-  ms->s = (KDSource **)malloc(ulen * sizeof(KDSource *));
-  ms->ws = (double *)malloc(ulen * sizeof(double));
+  ms->s = (KDSource **)KDS_calloc_i(len, sizeof(KDSource *));
+  ms->ws = (double *)KDS_calloc_i(len, sizeof(double));
   ms->J = 0;
   int i;
   for (i = 0; i < len; i++) {
@@ -339,7 +358,7 @@ MultiSource *MS_create(int len, KDSource **s, const double *ws) {
     ms->ws[i] = ws[i];
     ms->J += s[i]->J;
   }
-  ms->cdf = (double *)malloc(ulen * sizeof(double));
+  ms->cdf = (double *)KDS_calloc_i(len, sizeof(double));
   for (i = 0; i < ms->len; i++)
     ms->cdf[i] = ms->ws[i];
   for (i = 1; i < ms->len; i++)
@@ -350,8 +369,7 @@ MultiSource *MS_create(int len, KDSource **s, const double *ws) {
 MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws) {
   if (len < 1)
     KDS_error("Error in MS_open: invalid value of \"len\"");
-  const unsigned ulen = (unsigned)(len);
-  KDSource **s = malloc(sizeof(KDSource *) * ulen);
+  KDSource **s = KDS_calloc_i(len, sizeof(KDSource *));
   if (!s) {
     KDS_error("Error in MS_open: memory allocation failure");
     return NULL;
@@ -373,7 +391,7 @@ int MS_rand_sample2(kds_rng_fct_t rng, MultiSource *ms, mcpl_particle_t *part,
   else
     for (i = 0; y * ms->cdf[ms->len - 1] > ms->cdf[i]; i++)
       ;
-  ret = KDS_rand_sample2(rng,ms->s[i], part, perturb, w_crit, bias, loop);
+  ret = KDS_rand_sample2(rng, ms->s[i], part, perturb, w_crit, bias, loop);
   if (ms->cdf[ms->len - 1] > 0)
     part->weight *= (ms->s[i]->J / ms->J) / (ms->ws[i] / ms->cdf[ms->len - 1]);
   else
@@ -398,15 +416,15 @@ int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
 
 double MS_w_mean(MultiSource *ms, int N, WeightFun bias) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return MS_rand_w_mean(rng,ms,N,bias);
+  return MS_rand_w_mean(rng, ms, N, bias);
 }
 
-double MS_rand_w_mean(kds_rng_fct_t rng,
-                      MultiSource *ms, int N, WeightFun bias) {
+double MS_rand_w_mean(kds_rng_fct_t rng, MultiSource *ms, int N,
+                      WeightFun bias) {
   double w_mean = 0;
   int i;
   for (i = 0; i < ms->len; i++)
-    w_mean += ms->ws[i] * KDS_rand_w_mean(rng,ms->s[i], N, bias);
+    w_mean += ms->ws[i] * KDS_rand_w_mean(rng, ms->s[i], N, bias);
   return w_mean / ms->cdf[ms->len - 1];
 }
 

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -102,15 +102,16 @@ KDSource *KDS_open(const char *xmlfilename) {
          &order); // Read order
   if (order < 1)
     KDS_error("Error in KDS_open: invalid value of \"order\"");
+  const unsigned uorder = (unsigned)(order);
 
-  int *dims = malloc(sizeof(int) * order);
-  int *nps = malloc(sizeof(int) * order);
-  double **params = malloc(sizeof(double *) * order);
-  double **scalings = malloc(sizeof(double *) * order);
+  int *dims = malloc(sizeof(int) * uorder);
+  int *nps = malloc(sizeof(int) * uorder);
+  double **params = malloc(sizeof(double *) * uorder);
+  double **scalings = malloc(sizeof(double *) * uorder);
   char(*metricnames)[NAME_MAX_LEN] =
-      malloc(sizeof(char) * NAME_MAX_LEN * order);
-  PerturbFun *perturbs = malloc(sizeof(PerturbFun) * order);
-  Metric **metrics = malloc(sizeof(Metric *) * order);
+      malloc(sizeof(char) * NAME_MAX_LEN * uorder);
+  PerturbFun *perturbs = malloc(sizeof(PerturbFun) * uorder);
+  Metric **metrics = malloc(sizeof(Metric *) * uorder);
 
   if (!dims || !nps || !params || !scalings || !perturbs || !metricnames ||
       !metrics) {
@@ -130,11 +131,18 @@ KDSource *KDS_open(const char *xmlfilename) {
     strcpy(metricnames[i], (char *)mtree->name);             // Read metricname
     node = mtree->children;                                  // Node: dim
     sscanf((char *)xmlNodeGetContent(node), "%d", &dims[i]); // Read dim
-    scalings[i] = (double *)malloc(dims[i] * sizeof(double));
+
+    if (dims[i] < 1)
+      KDS_error("Error in KDS_open: invalid value of \"dims[i]\"");
+    const unsigned udimsi = (unsigned)(dims[i]);
+    scalings[i] = (double *)malloc(udimsi * sizeof(double));
     node = node->next; // Node: params
     sscanf((char *)xmlGetProp(node, (const xmlChar *)"nps"), "%d",
            &nps[i]); // Read ngp
-    params[i] = (double *)malloc(nps[i] * sizeof(double));
+    if (nps[i] < 1)
+      KDS_error("Error in KDS_open: invalid value of \"nps[i]\"");
+    const unsigned unpsi = (unsigned)(nps[i]);
+    params[i] = (double *)malloc(unpsi * sizeof(double));
     buf = (char *)xmlNodeGetContent(node);
     for (j = 0; j < nps[i]; j++) { // Read params
       sscanf(buf, "%lf %n", &params[i][j], &n);
@@ -291,10 +299,9 @@ int KDS_sample(KDSource *kds, mcpl_particle_t *part) {
 
 double KDS_w_mean(KDSource *kds, int N, WeightFun bias) {
   int i;
-  char pt;
+  //char pt;
   mcpl_particle_t part;
   double w_mean = 0;
-  ;
   for (i = 0; i < N; i++) {
     KDS_sample2(kds, &part, 0, -1, NULL, 1);
     if (bias)
@@ -313,9 +320,13 @@ void KDS_destroy(KDSource *kds) {
 
 MultiSource *MS_create(int len, KDSource **s, const double *ws) {
   MultiSource *ms = (MultiSource *)malloc(sizeof(MultiSource));
+
+  if (len < 1)
+    KDS_error("Error in MS_create: invalid value of \"len\"");
+  const unsigned ulen = (unsigned)(len);
   ms->len = len;
-  ms->s = (KDSource **)malloc(len * sizeof(KDSource *));
-  ms->ws = (double *)malloc(len * sizeof(double));
+  ms->s = (KDSource **)malloc(ulen * sizeof(KDSource *));
+  ms->ws = (double *)malloc(ulen * sizeof(double));
   ms->J = 0;
   int i;
   for (i = 0; i < len; i++) {
@@ -323,7 +334,7 @@ MultiSource *MS_create(int len, KDSource **s, const double *ws) {
     ms->ws[i] = ws[i];
     ms->J += s[i]->J;
   }
-  ms->cdf = (double *)malloc(ms->len * sizeof(double));
+  ms->cdf = (double *)malloc(ulen * sizeof(double));
   for (i = 0; i < ms->len; i++)
     ms->cdf[i] = ms->ws[i];
   for (i = 1; i < ms->len; i++)
@@ -332,8 +343,10 @@ MultiSource *MS_create(int len, KDSource **s, const double *ws) {
 }
 
 MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws) {
-
-  KDSource **s = malloc(sizeof(KDSource *) * len);
+  if (len < 1)
+    KDS_error("Error in MS_open: invalid value of \"len\"");
+  const unsigned ulen = (unsigned)(len);
+  KDSource **s = malloc(sizeof(KDSource *) * ulen);
   if (!s) {
     KDS_error("Error in MS_open: memory allocation failure");
     return NULL;

--- a/clib/src/plist.c
+++ b/clib/src/plist.c
@@ -10,6 +10,7 @@
 void KDS_error(const char *msg);
 void KDS_end(const char *msg);
 void *KDS_malloc(size_t);
+void KDS_strcpyname(char *dst, const char *src);
 
 PList *PList_create(char pt, const char *filename, const double *trasl,
                     const double *rot, int switch_x2z) {
@@ -22,7 +23,7 @@ PList *PList_create(char pt, const char *filename, const double *trasl,
     KDS_error("Too many particles in file (exceeds long long range)\n");
   plist->npts = (long long)(npts_uint64);
   plist->filename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
-  strcpy(plist->filename, filename);
+  KDS_strcpyname(plist->filename, filename);
   plist->file = file;
   int i;
   if (trasl) {
@@ -47,7 +48,7 @@ PList *PList_copy(const PList *from) {
   PList *plist = (PList *)KDS_malloc(sizeof(PList));
   *plist = *from;
   plist->filename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
-  strcpy(plist->filename, from->filename);
+  KDS_strcpyname(plist->filename, from->filename);
   plist->file = mcpl_open_file(plist->filename);
   int i;
   if (from->trasl) {

--- a/clib/src/plist.c
+++ b/clib/src/plist.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include <math.h>
+#include <limits.h>
 
 #include "kdsource/kdsource.h"
 
@@ -15,7 +16,10 @@ PList *PList_create(char pt, const char *filename, const double *trasl,
   plist->pt = pt;
   plist->pdgcode = pt2pdg(pt);
   mcpl_file_t file = mcpl_open_file(filename);
-  plist->npts = mcpl_hdr_nparticles(file);
+  uint64_t npts_uint64 = mcpl_hdr_nparticles(file);
+  if ( npts_uint64 > (uint64_t)LLONG_MAX )
+    KDS_error("Too many particles in file (exceeds long long range)\n");
+  plist->npts = (long long)(npts_uint64);
   plist->filename = (char *)malloc(NAME_MAX_LEN * sizeof(char));
   strcpy(plist->filename, filename);
   plist->file = file;

--- a/clib/src/plist.c
+++ b/clib/src/plist.c
@@ -2,36 +2,37 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <math.h>
 #include <limits.h>
+#include <math.h>
 
 #include "kdsource/kdsource.h"
 
 void KDS_error(const char *msg);
 void KDS_end(const char *msg);
+void *KDS_malloc(size_t);
 
 PList *PList_create(char pt, const char *filename, const double *trasl,
                     const double *rot, int switch_x2z) {
-  PList *plist = (PList *)malloc(sizeof(PList));
+  PList *plist = (PList *)KDS_malloc(sizeof(PList));
   plist->pt = pt;
   plist->pdgcode = pt2pdg(pt);
   mcpl_file_t file = mcpl_open_file(filename);
   uint64_t npts_uint64 = mcpl_hdr_nparticles(file);
-  if ( npts_uint64 > (uint64_t)LLONG_MAX )
+  if (npts_uint64 > (uint64_t)LLONG_MAX)
     KDS_error("Too many particles in file (exceeds long long range)\n");
   plist->npts = (long long)(npts_uint64);
-  plist->filename = (char *)malloc(NAME_MAX_LEN * sizeof(char));
+  plist->filename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
   strcpy(plist->filename, filename);
   plist->file = file;
   int i;
   if (trasl) {
-    plist->trasl = (double *)malloc(3 * sizeof(double));
+    plist->trasl = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       plist->trasl[i] = trasl[i];
   } else
     plist->trasl = NULL;
   if (rot) {
-    plist->rot = (double *)malloc(3 * sizeof(double));
+    plist->rot = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       plist->rot[i] = rot[i];
   } else
@@ -43,19 +44,19 @@ PList *PList_create(char pt, const char *filename, const double *trasl,
 }
 
 PList *PList_copy(const PList *from) {
-  PList *plist = (PList *)malloc(sizeof(PList));
+  PList *plist = (PList *)KDS_malloc(sizeof(PList));
   *plist = *from;
-  plist->filename = (char *)malloc(NAME_MAX_LEN * sizeof(char));
+  plist->filename = (char *)KDS_malloc(NAME_MAX_LEN * sizeof(char));
   strcpy(plist->filename, from->filename);
   plist->file = mcpl_open_file(plist->filename);
   int i;
   if (from->trasl) {
-    plist->trasl = (double *)malloc(3 * sizeof(double));
+    plist->trasl = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       plist->trasl[i] = from->trasl[i];
   }
   if (from->rot) {
-    plist->rot = (double *)malloc(3 * sizeof(double));
+    plist->rot = (double *)KDS_malloc(3 * sizeof(double));
     for (i = 0; i < 3; i++)
       plist->rot[i] = from->rot[i];
   }

--- a/clib/src/resamplemcpl.c
+++ b/clib/src/resamplemcpl.c
@@ -2,7 +2,7 @@
 #include "kdsource/kdsource.h"
 #include <stdint.h>
 
-void kdsource_resample_to_mcpl(const char *kds_sourcefile,
+void kdsource_resample_to_mcpl(kds_rng_fct_t rng, const char *kds_sourcefile,
                                const char *destination_mcpl, uint64_t nout) {
   const char *filename = kds_sourcefile;
   const char *outfilename = destination_mcpl;
@@ -20,7 +20,7 @@ void kdsource_resample_to_mcpl(const char *kds_sourcefile,
   uint64_t i;
   mcpl_particle_t *part = mcpl_get_empty_particle(file);
   for (i = 0; i < nout; ++i) {
-    KDS_sample2(kds, part, 1, w_crit, NULL, 1);
+    KDS_rand_sample2(rng, kds, part, 1, w_crit, NULL, 1);
     mcpl_add_particle(file, part);
   }
   mcpl_closeandgzip_outfile(file);

--- a/clib/src/utils.c
+++ b/clib/src/utils.c
@@ -14,7 +14,7 @@ void kds_rand_norm_twovals(kds_rng_fct_t rng, double *v1, double *v2) {
     g1 = 2.0 * rng() - 1.0;
     g2 = 2.0 * rng() - 1.0;
     t = g1 * g1 + g2 * g2;
-  } while (t >= 1.0 || !t);
+  } while (t >= 1.0 || t == 0.0);
   t = sqrt((-2.0 * log(t)) / t);
   *v1 = g1 * t;
   *v2 = g2 * t;

--- a/clib/src/utils.c
+++ b/clib/src/utils.c
@@ -6,18 +6,38 @@
 
 #define KDS_PI 3.1415926535897932384626433832795028841971694
 
+void kds_rand_norm_twovals(kds_rng_fct_t rng, double *v1, double *v2) {
+  // sample two independent values from a unit normal distribution via the polar
+  // method. The loop runs on average 4/pi ~= 1.27 times.
+  double t, g1, g2;
+  do {
+    g1 = 2.0 * rng() - 1.0;
+    g2 = 2.0 * rng() - 1.0;
+    t = g1 * g1 + g2 * g2;
+  } while (t >= 1.0 || !t);
+  t = sqrt((-2.0 * log(t)) / t);
+  *v1 = g1 * t;
+  *v2 = g2 * t;
+}
+
 // Sample with normal distribution (x0=0, s=1)
-double rand_norm() {
-  double y1 = (double)(rand() + 1) / ((double)RAND_MAX + 1),
-         y2 = rand() / (double)RAND_MAX;
-  return sqrt(-2 * log(y1)) * cos(2 * KDS_PI * y2);
+double kds_rand_norm(kds_rng_fct_t rng) {
+  double v1, v2;
+  kds_rand_norm_twovals(rng, &v1, &v2);
+  return v1;
 }
 
 // Sample with Epanechnikov distribution (x0=0, s=1)
-double rand_epan() {
-  double x1 = (double)rand() / ((double)RAND_MAX / 2.0) - 1.0;
-  double x2 = (double)rand() / ((double)RAND_MAX / 2.0) - 1.0;
-  double x3 = (double)rand() / ((double)RAND_MAX / 2.0) - 1.0;
+double kds_rand_epan(kds_rng_fct_t rng) {
+  // NB: Alternative simpler implementation:
+  //   double x;
+  //   do {
+  //     x = rng() * 2.0 - 1.0;
+  //   } while( rng() > 1.0 - x*x );
+  //   return x;
+  double x1 = rng() * 2.0 - 1.0;
+  double x2 = rng() * 2.0 - 1.0;
+  double x3 = rng() * 2.0 - 1.0;
   if (fabs(x3) >= fabs(x2) && fabs(x3) >= fabs(x1))
     return x2;
   else
@@ -25,19 +45,16 @@ double rand_epan() {
 }
 
 // Sample with Tophat distribution (x0=0, s=1)
-double rand_box() {
-  double y1 = (double)rand() / ((double)RAND_MAX / 2.0) - 1.0;
-  return y1;
-}
+double kds_rand_box(kds_rng_fct_t rng) { return rng() * 2.0 - 1.0; }
 
 // Sample depending on kernel selected
-double rand_type(char kernel) {
+double kds_rand_type(kds_rng_fct_t rng, char kernel) {
   if (kernel == 'g')
-    return rand_norm();
+    return kds_rand_norm(rng);
   if (kernel == 'e')
-    return rand_epan();
+    return kds_rand_epan(rng);
   if (kernel == 'b')
-    return rand_box();
+    return kds_rand_box(rng);
   else {
     printf("Cannot perturbate with current kernel. \n");
     // KDS_error("Cannot perturbate with current kernel.");

--- a/clib/src/utils.c
+++ b/clib/src/utils.c
@@ -49,18 +49,18 @@ double kds_rand_box(kds_rng_fct_t rng) { return rng() * 2.0 - 1.0; }
 
 // Sample depending on kernel selected
 double kds_rand_type(kds_rng_fct_t rng, char kernel) {
-  if (kernel == 'g')
+  if (kernel == 'g') {
     return kds_rand_norm(rng);
-  if (kernel == 'e')
+  } else if (kernel == 'e') {
     return kds_rand_epan(rng);
-  if (kernel == 'b')
+  }
+  if (kernel == 'b') {
     return kds_rand_box(rng);
-  else {
+  } else {
     printf("Cannot perturbate with current kernel. \n");
     // KDS_error("Cannot perturbate with current kernel.");
     return 0;
   }
-  return 0;
 }
 
 // Translation

--- a/python/kdsource/_chooks.py
+++ b/python/kdsource/_chooks.py
@@ -26,14 +26,19 @@ def _load_fcts():
     lib = _loadlib_kdsource()
 
     ###### resample_to_mcpl
+    kds_rng_fct_t = ctypes.CFUNCTYPE( ctypes.c_double )
     rawfct_rs = lib.kdsource_resample_to_mcpl
     rawfct_rs.restype=None
-    rawfct_rs.argtypes=(ctypes.c_char_p,ctypes.c_char_p,ctypes.c_uint64)
-    def fct( kds_sourcefile, destination_mcpl, nout ):
-        rawfct_rs( _str2cstr(kds_sourcefile),
+    rawfct_rs.argtypes=( kds_rng_fct_t,
+                         ctypes.c_char_p,
+                         ctypes.c_char_p,
+                         ctypes.c_uint64 )
+    def fct_rs( rng_fct, kds_sourcefile, destination_mcpl, nout ):
+        rawfct_rs( kds_rng_fct_t(rng_fct),
+                   _str2cstr(kds_sourcefile),
                    _str2cstr(destination_mcpl),
                    ctypes.c_uint64(nout) )
-    allfcts['resample_to_mcpl'] = fct
+    allfcts['resample_to_mcpl'] = fct_rs
 
     ###### write_mcpl
     dblptr = ctypes.POINTER(ctypes.c_double)
@@ -57,9 +62,9 @@ def _load_fcts():
             keepalive.append( ndarray_fix_type(a,dtypename) )
             return keepalive[-1].ctypes.data_as(cptr)
         return ndarray_to_cptr
-    def fct( filename, nparticles,
-             ekin, x, y, z, ux, uy, uz, time, weight, pdgcode,
-             polx, poly, polz, userflags, double_prec ):
+    def fct_wm( filename, nparticles,
+                ekin, x, y, z, ux, uy, uz, time, weight, pdgcode,
+                polx, poly, polz, userflags, double_prec ):
         import numbers
         flags = 1 if double_prec else 0
         keepalive=[]
@@ -90,7 +95,7 @@ def _load_fcts():
                    a2c(keepalive,ux), a2c(keepalive,uy), a2c(keepalive,uz),
                    a2c(keepalive,time), weight_arg, pdgcode_arg,
                    c_polx, c_poly, c_polz, c_userflags )
-    allfcts['write_mcpl'] = fct
+    allfcts['write_mcpl'] = fct_wm
 
     __cache_fcts[0]=allfcts
     return __cache_fcts[0]

--- a/python/kdsource/_cli_resample.py
+++ b/python/kdsource/_cli_resample.py
@@ -18,7 +18,11 @@ def parse_args(argv=None):
     parser.add_argument('nparticles',metavar='NPARTICLES',type=int,
                         help=wrap("""Number of particles to sample and place in
                         OUTMCPL."""))
-    parser.add_argument('--force',action='store_true',
+    parser.add_argument('-s','--seed',metavar='SEED',type=int,
+                        help=wrap("""Seed value of Number of particles to sample
+                        and place in OUTMCPL. If not set, a random seed is
+                        generated (based on bytes from os.urandom)."""))
+    parser.add_argument('-f','--force',action='store_true',
                         help=wrap("""Will overwrite existing file if it already
                         exists."""))
 
@@ -28,7 +32,7 @@ def main(argv=None):
     from .resample import resample_to_mcpl
     args = parse_args(argv)
     resample_to_mcpl( args.kdefile, args.outmcpl, args.nparticles,
-                      force=args.force)
+                      force=args.force, rng = args.seed )
 
 if __name__ == '__main__':
     main()

--- a/python/kdsource/resample.py
+++ b/python/kdsource/resample.py
@@ -1,11 +1,23 @@
 
-def resample_to_mcpl( kds_sourcefile, destination_mcpl, nout, force = False ):
-    """Resample n=nout particles from source (xml) file to a new MCPL file.
+def resample_to_mcpl( kds_sourcefile,
+                      destination_mcpl,
+                      nout,
+                      rng = None,
+                      force = False ):
+    """Resample nout particles from source (xml) file to a new MCPL file.
 
     Note that the extension of the produced file will always end up as .mcpl.gz,
     so it is least surprising if the provided destination_mcpl filename already
-    has such an extension.
+    has such an extension. It is an error if the output file already exists
+    unless force is False.
 
+    The rng parameter is used to control the stream of random numbers used for
+    the sampling. If set to an integer value or None, it will be interpreted as
+    a seed value, and a dedicated RNG stream will be created according to
+    random.Random(seed_value). In case of rng=None, the seed value will be
+    generated based on randomness from os.urandom. Finally, the rng parameter
+    can be a function pointer to a function returning floating point values
+    sampled uniformly in [0,1).
     """
     import pathlib
     from .writemcpl import _check_new_mcpl_filename
@@ -17,5 +29,21 @@ def resample_to_mcpl( kds_sourcefile, destination_mcpl, nout, force = False ):
     if nout <= 0 or nout > 1e16:
         raise RuntimeError('Invalid (or unreasonable) number of'
                            f' particles requested: {nout}')
+    #Setup RNG function:
+    if rng is None:
+        import os
+        rng = int.from_bytes(os.urandom(8), byteorder="big")
+        print( "Warning: No explicit seed provided"
+               f" (choosing arbitrarily seed={rng})" )
+    if isinstance( rng, int ):
+        import random
+        custom_stream = random.Random(rng)
+        rngfct = custom_stream.random
+    else:
+        rngfct = rng
+    #Call C implementation:
     from ._chooks import _load_fcts
-    _load_fcts()['resample_to_mcpl']( ksrc.absolute(), dst.absolute(), nout )
+    _load_fcts()['resample_to_mcpl']( rngfct,
+                                      ksrc.absolute(),
+                                      dst.absolute(),
+                                      nout )

--- a/python/kdsource/test.py
+++ b/python/kdsource/test.py
@@ -61,7 +61,7 @@ def test_resample():
     outpath = pathlib.Path(outfn)
     if outpath.is_file():
         outpath.unlink()
-    resample_to_mcpl( 'source.xml', outfn, 117, force=True )
+    resample_to_mcpl( 'source.xml', outfn, 117, rng=12345, force=True )
     if not outpath.is_file():
         raise RuntimeError('Test failed: did not create resampled MCPL file')
     f = mcpl.MCPLFile('foo_tmp_testfile.mcpl.gz')


### PR DESCRIPTION
This PR changes the C lib so that any usage of random numbers is done through a function pointer, which can ultimately be provided by the user when calling functions to request resampling of events.

These four old functions are kept as backwards compatibility and will use the C ` rand() / (RAND_MAX+1.0)` which was previously hardcoded everywhere:

```c
int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
                double w_crit, WeightFun bias, int loop);
int KDS_sample(KDSource *kds, mcpl_particle_t *part);
int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
               double w_crit, WeightFun bias, int loop);
int MS_sample(MultiSource *ms, mcpl_particle_t *part);
```
However, four new functions are instead added which allows the caller to provide the random numbers:
```c
typedef double (*kds_rng_fct_t)(void);
int KDS_rand_sample2(kds_rng_fct_t,
                     KDSource *kds, mcpl_particle_t *part, int perturb,
                     double w_crit, WeightFun bias, int loop);
int KDS_rand_sample(kds_rng_fct_t, KDSource *kds, mcpl_particle_t *part);
int MS_rand_sample2(kds_rng_fct_t,
                    MultiSource *ms, mcpl_particle_t *part, int perturb,
                    double w_crit, WeightFun bias, int loop);
int MS_rand_sample(kds_rng_fct_t, MultiSource *ms, mcpl_particle_t *part);
```
Additionally the Python API is updated, so the `kdsource.resample.resample_to_mcpl` function now gets a new `rng` parameter which allows the caller to control the RNG stream by either providing a seed or a function (the default is to generate a seed via os.urandom):
```
Help on function resample_to_mcpl in module kdsource.resample:

resample_to_mcpl(kds_sourcefile, destination_mcpl, nout, rng=None, force=False)
    Resample nout particles from source (xml) file to a new MCPL file.

    Note that the extension of the produced file will always end up as .mcpl.gz,
    so it is least surprising if the provided destination_mcpl filename already
    has such an extension. It is an error if the output file already exists
    unless force is False.

    The rng parameter is used to control the stream of random numbers used for
    the sampling. If set to an integer value or None, it will be interpreted as
    a seed value, and a dedicated RNG stream will be created according to
    random.Random(seed_value). In case of rng=None, the seed value will be
    generated based on randomness from os.urandom. Finally, the rng parameter
    can be a function pointer to a function returning floating point values
    sampled uniformly in [0,1).
```
Likewise the `kdsource-resample` command also gets a new `--seed` option to control the seed.

All in all this allows downstream application (like McStas) to resample using their own current RNG streams, it provides users of Python and CLI interfaces a proper modern RNG implementation with seed control, and it makes it possible to resample multiple mcpl files from the same source.xml, with full control of RNG states.