### PR TITLE
Stateful rng streams in the C API

### DIFF
--- a/clib/include/kdsource/geom.h
+++ b/clib/include/kdsource/geom.h
@@ -20,10 +20,10 @@ typedef struct Metric Metric;
 
 #ifndef KDS_RNG_FCT
 #define KDS_RNG_FCT
-typedef double (*kds_rng_fct_t)(void*);
+typedef double (*kds_rng_fct_t)(void *);
 #endif
 
-typedef int (*PerturbFun)(kds_rng_fct_t, void* rngstate, const Metric *metric,
+typedef int (*PerturbFun)(kds_rng_fct_t, void *rngstate, const Metric *metric,
                           mcpl_particle_t *part, double bw, char kernel);
 
 struct Metric {
@@ -55,41 +55,42 @@ Geometry *Geom_create(int ord, Metric **metrics, double bw,
                       const char *bwfilename, char kernel, const double *trasl,
                       const double *rot);
 Geometry *Geom_copy(const Geometry *from);
-int Geom_perturb(kds_rng_fct_t, void* rngstate, const Geometry *geom, mcpl_particle_t *part);
+int Geom_perturb(kds_rng_fct_t, void *rngstate, const Geometry *geom,
+                 mcpl_particle_t *part);
 int Geom_next(Geometry *geom, int loop);
 void Geom_destroy(Geometry *geom);
 
-int E_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-              double bw, char kernel);
-int Let_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                double bw, char kernel);
-int wl_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-               double bw, char kernel);
+int E_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+              mcpl_particle_t *part, double bw, char kernel);
+int Let_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                mcpl_particle_t *part, double bw, char kernel);
+int wl_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+               mcpl_particle_t *part, double bw, char kernel);
 
-int t_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-              double bw, char kernel);
-int Dec_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                double bw, char kernel);
+int t_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+              mcpl_particle_t *part, double bw, char kernel);
+int Dec_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                mcpl_particle_t *part, double bw, char kernel);
 
-int Vol_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                double bw, char kernel);
-int SurfXY_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                   double bw, char kernel);
-int SurfR_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                  double bw, char kernel);
-int SurfR2_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                   double bw, char kernel);
-int SurfCircle_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric,
+int Vol_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                mcpl_particle_t *part, double bw, char kernel);
+int SurfXY_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                   mcpl_particle_t *part, double bw, char kernel);
+int SurfR_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                  mcpl_particle_t *part, double bw, char kernel);
+int SurfR2_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                   mcpl_particle_t *part, double bw, char kernel);
+int SurfCircle_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
                        mcpl_particle_t *part, double bw, char kernel);
-int Guide_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                  double bw, char kernel);
+int Guide_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                  mcpl_particle_t *part, double bw, char kernel);
 
-int Isotrop_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                    double bw, char kernel);
-int Polar_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                  double bw, char kernel);
-int PolarMu_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                    double bw, char kernel);
+int Isotrop_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                    mcpl_particle_t *part, double bw, char kernel);
+int Polar_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                  mcpl_particle_t *part, double bw, char kernel);
+int PolarMu_perturb(kds_rng_fct_t, void *rngstate, const Metric *metric,
+                    mcpl_particle_t *part, double bw, char kernel);
 
 extern const int _n_metrics;
 extern const char *_metric_names[];

--- a/clib/include/kdsource/geom.h
+++ b/clib/include/kdsource/geom.h
@@ -20,10 +20,10 @@ typedef struct Metric Metric;
 
 #ifndef KDS_RNG_FCT
 #define KDS_RNG_FCT
-typedef double (*kds_rng_fct_t)(void);
+typedef double (*kds_rng_fct_t)(void*);
 #endif
 
-typedef int (*PerturbFun)(kds_rng_fct_t, const Metric *metric,
+typedef int (*PerturbFun)(kds_rng_fct_t, void* rngstate, const Metric *metric,
                           mcpl_particle_t *part, double bw, char kernel);
 
 struct Metric {
@@ -32,7 +32,6 @@ struct Metric {
   PerturbFun perturb; // Perturbation function
   int nps;            // Number of metric parameters
   double *params;     // Metric parameters
-  kds_rng_fct_t rng;  // Random number generator
 };
 
 Metric *Metric_create(int dim, const double *scaling, PerturbFun perturb,
@@ -56,40 +55,40 @@ Geometry *Geom_create(int ord, Metric **metrics, double bw,
                       const char *bwfilename, char kernel, const double *trasl,
                       const double *rot);
 Geometry *Geom_copy(const Geometry *from);
-int Geom_perturb(kds_rng_fct_t, const Geometry *geom, mcpl_particle_t *part);
+int Geom_perturb(kds_rng_fct_t, void* rngstate, const Geometry *geom, mcpl_particle_t *part);
 int Geom_next(Geometry *geom, int loop);
 void Geom_destroy(Geometry *geom);
 
-int E_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int E_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
               double bw, char kernel);
-int Let_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int Let_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                 double bw, char kernel);
-int wl_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int wl_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                double bw, char kernel);
 
-int t_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int t_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
               double bw, char kernel);
-int Dec_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int Dec_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                 double bw, char kernel);
 
-int Vol_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int Vol_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                 double bw, char kernel);
-int SurfXY_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int SurfXY_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                    double bw, char kernel);
-int SurfR_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int SurfR_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                   double bw, char kernel);
-int SurfR2_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int SurfR2_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                    double bw, char kernel);
-int SurfCircle_perturb(kds_rng_fct_t, const Metric *metric,
+int SurfCircle_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric,
                        mcpl_particle_t *part, double bw, char kernel);
-int Guide_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int Guide_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                   double bw, char kernel);
 
-int Isotrop_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int Isotrop_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                     double bw, char kernel);
-int Polar_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int Polar_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                   double bw, char kernel);
-int PolarMu_perturb(kds_rng_fct_t, const Metric *metric, mcpl_particle_t *part,
+int PolarMu_perturb(kds_rng_fct_t, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                     double bw, char kernel);
 
 extern const int _n_metrics;

--- a/clib/include/kdsource/kdsource.h.in
+++ b/clib/include/kdsource/kdsource.h.in
@@ -38,7 +38,7 @@
 
 #ifndef KDS_RNG_FCT
 #define KDS_RNG_FCT
-typedef double (*kds_rng_fct_t)(void);
+typedef double (*kds_rng_fct_t)(void*);
 #endif
 
 typedef double (*WeightFun)(const mcpl_particle_t *part);
@@ -52,10 +52,10 @@ typedef struct KDSource {
 
 KDSource *KDS_create(double J, char kernel, PList *plist, Geometry *geom);
 KDSource *KDS_open(const char *xmlfilename);
-int KDS_rand_sample2(kds_rng_fct_t, KDSource *kds, mcpl_particle_t *part,
+int KDS_rand_sample2(kds_rng_fct_t, void* rngstate, KDSource *kds, mcpl_particle_t *part,
                      int perturb, double w_crit, WeightFun bias, int loop);
-int KDS_rand_sample(kds_rng_fct_t, KDSource *kds, mcpl_particle_t *part);
-double KDS_rand_w_mean(kds_rng_fct_t, KDSource *kds, int N, WeightFun bias);
+int KDS_rand_sample(kds_rng_fct_t, void* rngstate, KDSource *kds, mcpl_particle_t *part);
+double KDS_rand_w_mean(kds_rng_fct_t, void* rngstate, KDSource *kds, int N, WeightFun bias);
 void KDS_destroy(KDSource *kds);
 
 typedef struct MultiSource {
@@ -68,10 +68,10 @@ typedef struct MultiSource {
 
 MultiSource *MS_create(int len, KDSource **s, const double *ws);
 MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws);
-int MS_rand_sample2(kds_rng_fct_t, MultiSource *ms, mcpl_particle_t *part,
+int MS_rand_sample2(kds_rng_fct_t, void* rngstate, MultiSource *ms, mcpl_particle_t *part,
                     int perturb, double w_crit, WeightFun bias, int loop);
-int MS_rand_sample(kds_rng_fct_t, MultiSource *ms, mcpl_particle_t *part);
-double MS_rand_w_mean(kds_rng_fct_t, MultiSource *ms, int N, WeightFun bias);
+int MS_rand_sample(kds_rng_fct_t, void* rngstate, MultiSource *ms, mcpl_particle_t *part);
+double MS_rand_w_mean(kds_rng_fct_t, void* rngstate, MultiSource *ms, int N, WeightFun bias);
 void MS_destroy(MultiSource *ms);
 
 // Backwards compatibility sampling functions without RNG control (not really

--- a/clib/include/kdsource/kdsource.h.in
+++ b/clib/include/kdsource/kdsource.h.in
@@ -38,7 +38,7 @@
 
 #ifndef KDS_RNG_FCT
 #define KDS_RNG_FCT
-typedef double (*kds_rng_fct_t)(void*);
+typedef double (*kds_rng_fct_t)(void *);
 #endif
 
 typedef double (*WeightFun)(const mcpl_particle_t *part);
@@ -52,10 +52,13 @@ typedef struct KDSource {
 
 KDSource *KDS_create(double J, char kernel, PList *plist, Geometry *geom);
 KDSource *KDS_open(const char *xmlfilename);
-int KDS_rand_sample2(kds_rng_fct_t, void* rngstate, KDSource *kds, mcpl_particle_t *part,
-                     int perturb, double w_crit, WeightFun bias, int loop);
-int KDS_rand_sample(kds_rng_fct_t, void* rngstate, KDSource *kds, mcpl_particle_t *part);
-double KDS_rand_w_mean(kds_rng_fct_t, void* rngstate, KDSource *kds, int N, WeightFun bias);
+int KDS_rand_sample2(kds_rng_fct_t, void *rngstate, KDSource *kds,
+                     mcpl_particle_t *part, int perturb, double w_crit,
+                     WeightFun bias, int loop);
+int KDS_rand_sample(kds_rng_fct_t, void *rngstate, KDSource *kds,
+                    mcpl_particle_t *part);
+double KDS_rand_w_mean(kds_rng_fct_t, void *rngstate, KDSource *kds, int N,
+                       WeightFun bias);
 void KDS_destroy(KDSource *kds);
 
 typedef struct MultiSource {
@@ -68,10 +71,13 @@ typedef struct MultiSource {
 
 MultiSource *MS_create(int len, KDSource **s, const double *ws);
 MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws);
-int MS_rand_sample2(kds_rng_fct_t, void* rngstate, MultiSource *ms, mcpl_particle_t *part,
-                    int perturb, double w_crit, WeightFun bias, int loop);
-int MS_rand_sample(kds_rng_fct_t, void* rngstate, MultiSource *ms, mcpl_particle_t *part);
-double MS_rand_w_mean(kds_rng_fct_t, void* rngstate, MultiSource *ms, int N, WeightFun bias);
+int MS_rand_sample2(kds_rng_fct_t, void *rngstate, MultiSource *ms,
+                    mcpl_particle_t *part, int perturb, double w_crit,
+                    WeightFun bias, int loop);
+int MS_rand_sample(kds_rng_fct_t, void *rngstate, MultiSource *ms,
+                   mcpl_particle_t *part);
+double MS_rand_w_mean(kds_rng_fct_t, void *rngstate, MultiSource *ms, int N,
+                      WeightFun bias);
 void MS_destroy(MultiSource *ms);
 
 // Backwards compatibility sampling functions without RNG control (not really

--- a/clib/include/kdsource/utils.h
+++ b/clib/include/kdsource/utils.h
@@ -17,12 +17,12 @@
 // random sampling:
 #ifndef KDS_RNG_FCT
 #define KDS_RNG_FCT
-typedef double (*kds_rng_fct_t)(void);
+typedef double (*kds_rng_fct_t)(void*);
 #endif
-double kds_rand_norm(kds_rng_fct_t);
-double kds_rand_epan(kds_rng_fct_t);
-double kds_rand_box(kds_rng_fct_t);
-double kds_rand_type(kds_rng_fct_t, char kernel);
+double kds_rand_norm(kds_rng_fct_t,void*rngstate);
+double kds_rand_epan(kds_rng_fct_t,void*rngstate);
+double kds_rand_box(kds_rng_fct_t,void*rngstate);
+double kds_rand_type(kds_rng_fct_t,void*rngstate, char kernel);
 
 double *traslv(double *vect, const double *trasl, int inverse);
 double *rotv(double *vect, const double *rotvec, int inverse);

--- a/clib/include/kdsource/utils.h
+++ b/clib/include/kdsource/utils.h
@@ -17,12 +17,12 @@
 // random sampling:
 #ifndef KDS_RNG_FCT
 #define KDS_RNG_FCT
-typedef double (*kds_rng_fct_t)(void*);
+typedef double (*kds_rng_fct_t)(void *);
 #endif
-double kds_rand_norm(kds_rng_fct_t,void*rngstate);
-double kds_rand_epan(kds_rng_fct_t,void*rngstate);
-double kds_rand_box(kds_rng_fct_t,void*rngstate);
-double kds_rand_type(kds_rng_fct_t,void*rngstate, char kernel);
+double kds_rand_norm(kds_rng_fct_t, void *rngstate);
+double kds_rand_epan(kds_rng_fct_t, void *rngstate);
+double kds_rand_box(kds_rng_fct_t, void *rngstate);
+double kds_rand_type(kds_rng_fct_t, void *rngstate, char kernel);
 
 double *traslv(double *vect, const double *trasl, int inverse);
 double *rotv(double *vect, const double *rotvec, int inverse);

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -136,7 +136,7 @@ Geometry *Geom_copy(const Geometry *from) {
   return geom;
 }
 
-int Geom_perturb(kds_rng_fct_t rng, const Geometry *geom,
+int Geom_perturb(kds_rng_fct_t rng, void* rngstate, const Geometry *geom,
                  mcpl_particle_t *part) {
   int i, ret = 0;
   if (geom->trasl)
@@ -146,7 +146,7 @@ int Geom_perturb(kds_rng_fct_t rng, const Geometry *geom,
     rotv(part->direction, geom->rot, 1);
   }
   for (i = 0; i < geom->ord; i++)
-    ret += geom->ms[i]->perturb(rng, geom->ms[i], part, geom->bw, geom->kernel);
+    ret += geom->ms[i]->perturb(rng, rngstate, geom->ms[i], part, geom->bw, geom->kernel);
   if (geom->rot) {
     rotv(part->position, geom->rot, 0);
     rotv(part->direction, geom->rot, 0);
@@ -188,67 +188,67 @@ void Geom_destroy(Geometry *geom) {
   free(geom);
 }
 
-int E_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+int E_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
               double bw, char kernel) {
-  part->ekin += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  part->ekin += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   if (part->ekin < 0)
     part->ekin *= -1;
   return 0;
 }
 
-int Let_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+int Let_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                 double bw, char kernel) {
   double E = part->ekin;
-  E *= exp(bw * metric->scaling[0] * kds_rand_type(rng, kernel));
+  E *= exp(bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel));
   while (E > metric->params[0]) {
     E = part->ekin;
-    E *= exp(bw * metric->scaling[0] * kds_rand_type(rng, kernel));
+    E *= exp(bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel));
   }
   part->ekin = E;
   return 0;
 }
 
-int wl_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+int wl_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                double bw, char kernel) {
   double wl = 9.045 / sqrt(part->ekin * 1e9);
-  double wl2 = wl + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  double wl2 = wl + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   part->ekin = 81.82e-9 / (wl2 * wl2);
   if (part->ekin < 0)
     part->ekin *= -1;
   return 0;
 }
 
-int t_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+int t_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
               double bw, char kernel) {
-  part->time += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  part->time += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   return 0;
 }
-int Dec_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+int Dec_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                 double bw, char kernel) {
-  part->time *= pow(10, bw * metric->scaling[0] * kds_rand_type(rng, kernel));
+  part->time *= pow(10, bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel));
   return 0;
 }
 
-int Vol_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
+int Vol_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
                 double bw, char kernel) {
   double xmin = metric->params[0], xmax = metric->params[1];
   double ymin = metric->params[2], ymax = metric->params[3];
   double zmin = metric->params[4], zmax = metric->params[5];
-  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[0] < xmin) || (part->position[0] > xmax)) {
     if (part->position[0] < xmin)
       part->position[0] += 2 * (xmin - part->position[0]);
     else
       part->position[0] -= 2 * (part->position[0] - xmax);
   }
-  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, kernel);
+  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[1] < ymin) || (part->position[1] > ymax)) {
     if (part->position[1] < ymin)
       part->position[1] += 2 * (ymin - part->position[1]);
     else
       part->position[1] -= 2 * (part->position[1] - ymax);
   }
-  part->position[2] += bw * metric->scaling[2] * kds_rand_type(rng, kernel);
+  part->position[2] += bw * metric->scaling[2] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[2] < zmin) || (part->position[2] > zmax)) {
     if (part->position[2] < zmin)
       part->position[2] += 2 * (zmin - part->position[2]);
@@ -257,18 +257,18 @@ int Vol_perturb(kds_rng_fct_t rng, const Metric *metric, mcpl_particle_t *part,
   }
   return 0;
 }
-int SurfXY_perturb(kds_rng_fct_t rng, const Metric *metric,
+int SurfXY_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                    mcpl_particle_t *part, double bw, char kernel) {
   double xmin = metric->params[0], xmax = metric->params[1];
   double ymin = metric->params[2], ymax = metric->params[3];
-  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[0] < xmin) || (part->position[0] > xmax)) {
     if (part->position[0] < xmin)
       part->position[0] += 2 * (xmin - part->position[0]);
     else
       part->position[0] -= 2 * (part->position[0] - xmax);
   }
-  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, kernel);
+  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[1] < ymin) || (part->position[1] > ymax)) {
     if (part->position[1] < ymin)
       part->position[1] += 2 * (ymin - part->position[1]);
@@ -277,7 +277,7 @@ int SurfXY_perturb(kds_rng_fct_t rng, const Metric *metric,
   }
   return 0;
 }
-int SurfR_perturb(kds_rng_fct_t rng, const Metric *metric,
+int SurfR_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                   mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
@@ -287,9 +287,9 @@ int SurfR_perturb(kds_rng_fct_t rng, const Metric *metric,
              part->position[1] * part->position[1]);
   psi = atan2(part->position[1], part->position[0]);
 
-  rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   psi2 =
-      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
+      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
 
   while ((rho2 < rho_min) || (rho2 > rho_max)) {
     if (rho2 < rho_min)
@@ -309,7 +309,7 @@ int SurfR_perturb(kds_rng_fct_t rng, const Metric *metric,
   part->position[1] = rho2 * sin(psi2);
   return 0;
 }
-int SurfR2_perturb(kds_rng_fct_t rng, const Metric *metric,
+int SurfR2_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                    mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
@@ -322,9 +322,9 @@ int SurfR2_perturb(kds_rng_fct_t rng, const Metric *metric,
         part->position[1] * part->position[1];
   psi = atan2(part->position[1], part->position[0]);
 
-  rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   psi2 =
-      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
+      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
 
   while ((rho2 < rho_min) || (rho2 > rho_max)) {
     if (rho2 < rho_min)
@@ -344,14 +344,14 @@ int SurfR2_perturb(kds_rng_fct_t rng, const Metric *metric,
   part->position[1] = sqrt(rho2) * sin(psi2);
   return 0;
 }
-int SurfCircle_perturb(kds_rng_fct_t rng, const Metric *metric,
+int SurfCircle_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                        mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
   double x, y, rho2 = 0, psi2 = 0;
 
-  x = part->position[0] + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
-  y = part->position[1] + bw * metric->scaling[1] * kds_rand_type(rng, kernel);
+  x = part->position[0] + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
+  y = part->position[1] + bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
 
   rho2 = sqrt(x * x + y * y);
   psi2 = atan2(y, x);
@@ -373,7 +373,7 @@ int SurfCircle_perturb(kds_rng_fct_t rng, const Metric *metric,
   part->position[1] = rho2 * sin(psi2);
   return 0;
 }
-int Guide_perturb(kds_rng_fct_t rng, const Metric *metric,
+int Guide_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                   mcpl_particle_t *part, double bw, char kernel) {
   double x = part->position[0], y = part->position[1], z = part->position[2];
   double dx = part->direction[0], dy = part->direction[1],
@@ -427,14 +427,14 @@ int Guide_perturb(kds_rng_fct_t rng, const Metric *metric,
     break;
   }
   // Perturb
-  z += bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  z += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   while ((z < 0) || (z > zmax)) {
     if (z < 0)
       z *= -1;
     else
       z -= 2 * (z - zmax);
   }
-  t += bw * metric->scaling[1] * kds_rand_type(rng, kernel);
+  t += bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
   switch (mirror) { // Avoid perturbation to change mirror
   case 0:
     while ((t < 0) || (t > yheight)) {
@@ -470,9 +470,9 @@ int Guide_perturb(kds_rng_fct_t rng, const Metric *metric,
     break;
   }
   if (isinf(metric->scaling[2]))
-    mu = -1 + 2. * rng();
+    mu = -1 + 2. * rng(rngstate);
   else {
-    mu2 = mu + bw * metric->scaling[2] * kds_rand_type(rng, kernel);
+    mu2 = mu + bw * metric->scaling[2] * kds_rand_type(rng, rngstate, kernel);
     if (mu >= 0) {
       while ((mu2 < 0) || (mu2 > 1)) {
         if (mu2 < 0)
@@ -491,9 +491,9 @@ int Guide_perturb(kds_rng_fct_t rng, const Metric *metric,
     mu = mu2;
   }
   if (isinf(metric->scaling[3]))
-    phi = 2. * KDS_PI * rng();
+    phi = 2. * KDS_PI * rng(rngstate);
   else
-    phi += bw * metric->scaling[3] * KDS_PI / 180 * kds_rand_type(rng, kernel);
+    phi += bw * metric->scaling[3] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
   // Antitransform from (z,t,theta_n,theta_t) to (x,y,z,dx,dy,dz)
   switch (mirror) {
   case 0:
@@ -543,12 +543,12 @@ int Guide_perturb(kds_rng_fct_t rng, const Metric *metric,
   return 0;
 }
 
-void _vMF_perturb(kds_rng_fct_t rng, double bw, double *dx, double *dy,
+void _vMF_perturb(kds_rng_fct_t rng, void* rngstate,double bw, double *dx, double *dy,
                   double *dz) {
-  double xi = rng();
+  double xi = rng(rngstate);
   double w = 1;
   w += bw * bw * log(xi + (1 - xi) * exp(-2 / (bw * bw)));
-  double phi = 2. * KDS_PI * rng();
+  double phi = 2. * KDS_PI * rng(rngstate);
   double uv = sqrt(1 - w * w), u = uv * cos(phi), v = uv * sin(phi);
   double dx0 = *dx, dy0 = *dy, dz0 = *dz;
   if (dz0 > 0) {
@@ -561,20 +561,20 @@ void _vMF_perturb(kds_rng_fct_t rng, double bw, double *dx, double *dy,
   *dz = w * dz0 - u * dx0 - v * dy0;
 }
 
-int Isotrop_perturb(kds_rng_fct_t rng, const Metric *metric,
+int Isotrop_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                     mcpl_particle_t *part, double bw, char kernel) {
   (void)kernel;                         // unused
   if (isinf(bw * metric->scaling[0])) { // Generate isotropic direction
-    part->direction[2] = -1 + 2. * rng();
+    part->direction[2] = -1 + 2. * rng(rngstate);
     double dxy = sqrt(1 - part->direction[2] * part->direction[2]);
-    double phi = 2. * KDS_PI * rng();
+    double phi = 2. * KDS_PI * rng(rngstate);
     part->direction[0] = dxy * cos(phi);
     part->direction[1] = dxy * sin(phi);
   } else if (bw * metric->scaling[0] >
              0) { // Perturb following von Mises-Fischer distribution
     double dx = part->direction[0], dy = part->direction[1],
            dz = part->direction[2];
-    _vMF_perturb(rng, bw * metric->scaling[0], &part->direction[0],
+    _vMF_perturb(rng, rngstate, bw * metric->scaling[0], &part->direction[0],
                  &part->direction[1], &part->direction[2]);
     int keepx = (int)metric->params[0], keepy = (int)metric->params[1],
         keepz = (int)metric->params[2];
@@ -588,31 +588,31 @@ int Isotrop_perturb(kds_rng_fct_t rng, const Metric *metric,
   return 0;
 }
 
-int Polar_perturb(kds_rng_fct_t rng, const Metric *metric,
+int Polar_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                   mcpl_particle_t *part, double bw, char kernel) {
   double theta, theta2, phi;
   // int cont = 0;
   theta = acos(part->direction[2]);
   phi = atan2(part->direction[1], part->direction[0]);
   theta2 = theta +
-           bw * metric->scaling[0] * KDS_PI / 180 * kds_rand_type(rng, kernel);
+           bw * metric->scaling[0] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
   if (cos(theta2) * cos(theta) < 0)
     theta += 2 * (KDS_PI / 2 - theta);
   theta = theta2;
-  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
+  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
   part->direction[0] = sin(theta) * cos(phi);
   part->direction[1] = sin(theta) * sin(phi);
   part->direction[2] = cos(theta);
   return 0;
 }
 
-int PolarMu_perturb(kds_rng_fct_t rng, const Metric *metric,
+int PolarMu_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
                     mcpl_particle_t *part, double bw, char kernel) {
   double mu, mu2, phi;
   // int cont = 0;
   mu = part->direction[2];
   phi = atan2(part->direction[1], part->direction[0]);
-  mu2 = mu + bw * metric->scaling[0] * kds_rand_type(rng, kernel);
+  mu2 = mu + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   if (mu >= 0) {
     while ((mu2 < 0) || (mu2 > 1)) {
       if (mu2 < 0)
@@ -629,7 +629,7 @@ int PolarMu_perturb(kds_rng_fct_t rng, const Metric *metric,
     }
   }
   mu = mu2;
-  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, kernel);
+  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
   part->direction[0] = sqrt(1 - mu * mu) * cos(phi);
   part->direction[1] = sqrt(1 - mu * mu) * sin(phi);
   part->direction[2] = mu;

--- a/clib/src/geom.c
+++ b/clib/src/geom.c
@@ -136,7 +136,7 @@ Geometry *Geom_copy(const Geometry *from) {
   return geom;
 }
 
-int Geom_perturb(kds_rng_fct_t rng, void* rngstate, const Geometry *geom,
+int Geom_perturb(kds_rng_fct_t rng, void *rngstate, const Geometry *geom,
                  mcpl_particle_t *part) {
   int i, ret = 0;
   if (geom->trasl)
@@ -146,7 +146,8 @@ int Geom_perturb(kds_rng_fct_t rng, void* rngstate, const Geometry *geom,
     rotv(part->direction, geom->rot, 1);
   }
   for (i = 0; i < geom->ord; i++)
-    ret += geom->ms[i]->perturb(rng, rngstate, geom->ms[i], part, geom->bw, geom->kernel);
+    ret += geom->ms[i]->perturb(rng, rngstate, geom->ms[i], part, geom->bw,
+                                geom->kernel);
   if (geom->rot) {
     rotv(part->position, geom->rot, 0);
     rotv(part->direction, geom->rot, 0);
@@ -188,16 +189,16 @@ void Geom_destroy(Geometry *geom) {
   free(geom);
 }
 
-int E_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-              double bw, char kernel) {
+int E_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
+              mcpl_particle_t *part, double bw, char kernel) {
   part->ekin += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   if (part->ekin < 0)
     part->ekin *= -1;
   return 0;
 }
 
-int Let_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                double bw, char kernel) {
+int Let_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
+                mcpl_particle_t *part, double bw, char kernel) {
   double E = part->ekin;
   E *= exp(bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel));
   while (E > metric->params[0]) {
@@ -208,47 +209,52 @@ int Let_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_pa
   return 0;
 }
 
-int wl_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-               double bw, char kernel) {
+int wl_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
+               mcpl_particle_t *part, double bw, char kernel) {
   double wl = 9.045 / sqrt(part->ekin * 1e9);
-  double wl2 = wl + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
+  double wl2 =
+      wl + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   part->ekin = 81.82e-9 / (wl2 * wl2);
   if (part->ekin < 0)
     part->ekin *= -1;
   return 0;
 }
 
-int t_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-              double bw, char kernel) {
+int t_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
+              mcpl_particle_t *part, double bw, char kernel) {
   part->time += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   return 0;
 }
-int Dec_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                double bw, char kernel) {
-  part->time *= pow(10, bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel));
+int Dec_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
+                mcpl_particle_t *part, double bw, char kernel) {
+  part->time *=
+      pow(10, bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel));
   return 0;
 }
 
-int Vol_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_particle_t *part,
-                double bw, char kernel) {
+int Vol_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
+                mcpl_particle_t *part, double bw, char kernel) {
   double xmin = metric->params[0], xmax = metric->params[1];
   double ymin = metric->params[2], ymax = metric->params[3];
   double zmin = metric->params[4], zmax = metric->params[5];
-  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
+  part->position[0] +=
+      bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[0] < xmin) || (part->position[0] > xmax)) {
     if (part->position[0] < xmin)
       part->position[0] += 2 * (xmin - part->position[0]);
     else
       part->position[0] -= 2 * (part->position[0] - xmax);
   }
-  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
+  part->position[1] +=
+      bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[1] < ymin) || (part->position[1] > ymax)) {
     if (part->position[1] < ymin)
       part->position[1] += 2 * (ymin - part->position[1]);
     else
       part->position[1] -= 2 * (part->position[1] - ymax);
   }
-  part->position[2] += bw * metric->scaling[2] * kds_rand_type(rng, rngstate, kernel);
+  part->position[2] +=
+      bw * metric->scaling[2] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[2] < zmin) || (part->position[2] > zmax)) {
     if (part->position[2] < zmin)
       part->position[2] += 2 * (zmin - part->position[2]);
@@ -257,18 +263,20 @@ int Vol_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric, mcpl_pa
   }
   return 0;
 }
-int SurfXY_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int SurfXY_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                    mcpl_particle_t *part, double bw, char kernel) {
   double xmin = metric->params[0], xmax = metric->params[1];
   double ymin = metric->params[2], ymax = metric->params[3];
-  part->position[0] += bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
+  part->position[0] +=
+      bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[0] < xmin) || (part->position[0] > xmax)) {
     if (part->position[0] < xmin)
       part->position[0] += 2 * (xmin - part->position[0]);
     else
       part->position[0] -= 2 * (part->position[0] - xmax);
   }
-  part->position[1] += bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
+  part->position[1] +=
+      bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
   while ((part->position[1] < ymin) || (part->position[1] > ymax)) {
     if (part->position[1] < ymin)
       part->position[1] += 2 * (ymin - part->position[1]);
@@ -277,7 +285,7 @@ int SurfXY_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   }
   return 0;
 }
-int SurfR_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int SurfR_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                   mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
@@ -288,8 +296,8 @@ int SurfR_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   psi = atan2(part->position[1], part->position[0]);
 
   rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
-  psi2 =
-      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
+  psi2 = psi + bw * metric->scaling[1] * KDS_PI / 180 *
+                   kds_rand_type(rng, rngstate, kernel);
 
   while ((rho2 < rho_min) || (rho2 > rho_max)) {
     if (rho2 < rho_min)
@@ -309,7 +317,7 @@ int SurfR_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   part->position[1] = rho2 * sin(psi2);
   return 0;
 }
-int SurfR2_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int SurfR2_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                    mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
@@ -323,8 +331,8 @@ int SurfR2_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   psi = atan2(part->position[1], part->position[0]);
 
   rho2 = rho + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
-  psi2 =
-      psi + bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
+  psi2 = psi + bw * metric->scaling[1] * KDS_PI / 180 *
+                   kds_rand_type(rng, rngstate, kernel);
 
   while ((rho2 < rho_min) || (rho2 > rho_max)) {
     if (rho2 < rho_min)
@@ -344,14 +352,16 @@ int SurfR2_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   part->position[1] = sqrt(rho2) * sin(psi2);
   return 0;
 }
-int SurfCircle_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int SurfCircle_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                        mcpl_particle_t *part, double bw, char kernel) {
   double rho_min = metric->params[0], rho_max = metric->params[1];
   double psi_min = metric->params[2], psi_max = metric->params[3];
   double x, y, rho2 = 0, psi2 = 0;
 
-  x = part->position[0] + bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
-  y = part->position[1] + bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
+  x = part->position[0] +
+      bw * metric->scaling[0] * kds_rand_type(rng, rngstate, kernel);
+  y = part->position[1] +
+      bw * metric->scaling[1] * kds_rand_type(rng, rngstate, kernel);
 
   rho2 = sqrt(x * x + y * y);
   psi2 = atan2(y, x);
@@ -373,7 +383,7 @@ int SurfCircle_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   part->position[1] = rho2 * sin(psi2);
   return 0;
 }
-int Guide_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int Guide_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                   mcpl_particle_t *part, double bw, char kernel) {
   double x = part->position[0], y = part->position[1], z = part->position[2];
   double dx = part->direction[0], dy = part->direction[1],
@@ -493,7 +503,8 @@ int Guide_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   if (isinf(metric->scaling[3]))
     phi = 2. * KDS_PI * rng(rngstate);
   else
-    phi += bw * metric->scaling[3] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
+    phi += bw * metric->scaling[3] * KDS_PI / 180 *
+           kds_rand_type(rng, rngstate, kernel);
   // Antitransform from (z,t,theta_n,theta_t) to (x,y,z,dx,dy,dz)
   switch (mirror) {
   case 0:
@@ -543,8 +554,8 @@ int Guide_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   return 0;
 }
 
-void _vMF_perturb(kds_rng_fct_t rng, void* rngstate,double bw, double *dx, double *dy,
-                  double *dz) {
+void _vMF_perturb(kds_rng_fct_t rng, void *rngstate, double bw, double *dx,
+                  double *dy, double *dz) {
   double xi = rng(rngstate);
   double w = 1;
   w += bw * bw * log(xi + (1 - xi) * exp(-2 / (bw * bw)));
@@ -561,7 +572,7 @@ void _vMF_perturb(kds_rng_fct_t rng, void* rngstate,double bw, double *dx, doubl
   *dz = w * dz0 - u * dx0 - v * dy0;
 }
 
-int Isotrop_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int Isotrop_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                     mcpl_particle_t *part, double bw, char kernel) {
   (void)kernel;                         // unused
   if (isinf(bw * metric->scaling[0])) { // Generate isotropic direction
@@ -588,25 +599,26 @@ int Isotrop_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
   return 0;
 }
 
-int Polar_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int Polar_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                   mcpl_particle_t *part, double bw, char kernel) {
   double theta, theta2, phi;
   // int cont = 0;
   theta = acos(part->direction[2]);
   phi = atan2(part->direction[1], part->direction[0]);
-  theta2 = theta +
-           bw * metric->scaling[0] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
+  theta2 = theta + bw * metric->scaling[0] * KDS_PI / 180 *
+                       kds_rand_type(rng, rngstate, kernel);
   if (cos(theta2) * cos(theta) < 0)
     theta += 2 * (KDS_PI / 2 - theta);
   theta = theta2;
-  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
+  phi += bw * metric->scaling[1] * KDS_PI / 180 *
+         kds_rand_type(rng, rngstate, kernel);
   part->direction[0] = sin(theta) * cos(phi);
   part->direction[1] = sin(theta) * sin(phi);
   part->direction[2] = cos(theta);
   return 0;
 }
 
-int PolarMu_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
+int PolarMu_perturb(kds_rng_fct_t rng, void *rngstate, const Metric *metric,
                     mcpl_particle_t *part, double bw, char kernel) {
   double mu, mu2, phi;
   // int cont = 0;
@@ -629,7 +641,8 @@ int PolarMu_perturb(kds_rng_fct_t rng, void* rngstate, const Metric *metric,
     }
   }
   mu = mu2;
-  phi += bw * metric->scaling[1] * KDS_PI / 180 * kds_rand_type(rng, rngstate, kernel);
+  phi += bw * metric->scaling[1] * KDS_PI / 180 *
+         kds_rand_type(rng, rngstate, kernel);
   part->direction[0] = sqrt(1 - mu * mu) * cos(phi);
   part->direction[1] = sqrt(1 - mu * mu) * sin(phi);
   part->direction[2] = mu;

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -34,7 +34,7 @@ void *KDS_calloc_i(int n_elem, size_t elem_size) {
   return KDS_calloc((size_t)(n_elem), elem_size);
 }
 
-double KDS_default_rngfct(void*) {
+double KDS_default_rngfct(void *) {
   // This is a horrible RNG. Also, simply uses global state!
   return rand() / (RAND_MAX + 1.0);
 }
@@ -278,8 +278,9 @@ KDSource *KDS_open(const char *xmlfilename) {
   return s;
 }
 
-int KDS_rand_sample2(kds_rng_fct_t rng, void* rngstate, KDSource *kds, mcpl_particle_t *part,
-                     int perturb, double w_crit, WeightFun bias, int loop) {
+int KDS_rand_sample2(kds_rng_fct_t rng, void *rngstate, KDSource *kds,
+                     mcpl_particle_t *part, int perturb, double w_crit,
+                     WeightFun bias, int loop) {
   int ret = 0;
   if (w_crit <= 0) {
     PList_get(kds->plist, part);
@@ -327,7 +328,8 @@ int KDS_rand_sample2(kds_rng_fct_t rng, void* rngstate, KDSource *kds, mcpl_part
   return ret;
 }
 
-int KDS_rand_sample(kds_rng_fct_t rng, void* rngstate, KDSource *kds, mcpl_particle_t *part) {
+int KDS_rand_sample(kds_rng_fct_t rng, void *rngstate, KDSource *kds,
+                    mcpl_particle_t *part) {
   return KDS_rand_sample2(rng, rngstate, kds, part, 1, 1, NULL, 1);
 }
 
@@ -347,7 +349,7 @@ double KDS_w_mean(KDSource *kds, int N, WeightFun bias) {
   return KDS_rand_w_mean(rng, NULL, kds, N, bias);
 }
 
-double KDS_rand_w_mean(kds_rng_fct_t rng, void* rngstate, KDSource *kds, int N,
+double KDS_rand_w_mean(kds_rng_fct_t rng, void *rngstate, KDSource *kds, int N,
                        WeightFun bias) {
   int i;
   // char pt;
@@ -410,8 +412,9 @@ MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws) {
   return result;
 }
 
-int MS_rand_sample2(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, mcpl_particle_t *part,
-                    int perturb, double w_crit, WeightFun bias, int loop) {
+int MS_rand_sample2(kds_rng_fct_t rng, void *rngstate, MultiSource *ms,
+                    mcpl_particle_t *part, int perturb, double w_crit,
+                    WeightFun bias, int loop) {
   double y = rng(rngstate);
   int i, ret;
   if (ms->cdf[ms->len - 1] <= 0)
@@ -419,7 +422,8 @@ int MS_rand_sample2(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, mcpl_par
   else
     for (i = 0; y * ms->cdf[ms->len - 1] > ms->cdf[i]; i++)
       ;
-  ret = KDS_rand_sample2(rng, rngstate, ms->s[i], part, perturb, w_crit, bias, loop);
+  ret = KDS_rand_sample2(rng, rngstate, ms->s[i], part, perturb, w_crit, bias,
+                         loop);
   if (ms->cdf[ms->len - 1] > 0)
     part->weight *= (ms->s[i]->J / ms->J) / (ms->ws[i] / ms->cdf[ms->len - 1]);
   else
@@ -427,7 +431,8 @@ int MS_rand_sample2(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, mcpl_par
   return ret;
 }
 
-int MS_rand_sample(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, mcpl_particle_t *part) {
+int MS_rand_sample(kds_rng_fct_t rng, void *rngstate, MultiSource *ms,
+                   mcpl_particle_t *part) {
   return MS_rand_sample2(rng, rngstate, ms, part, 1, 1, NULL, 1);
 }
 
@@ -447,7 +452,7 @@ double MS_w_mean(MultiSource *ms, int N, WeightFun bias) {
   return MS_rand_w_mean(rng, NULL, ms, N, bias);
 }
 
-double MS_rand_w_mean(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, int N,
+double MS_rand_w_mean(kds_rng_fct_t rng, void *rngstate, MultiSource *ms, int N,
                       WeightFun bias) {
   double w_mean = 0;
   int i;

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -34,8 +34,9 @@ void *KDS_calloc_i(int n_elem, size_t elem_size) {
   return KDS_calloc((size_t)(n_elem), elem_size);
 }
 
-double KDS_default_rngfct(void *) {
+double KDS_default_rngfct(void *rngstate) {
   // This is a horrible RNG. Also, simply uses global state!
+  (void)rngstate;
   return rand() / (RAND_MAX + 1.0);
 }
 

--- a/clib/src/kdsource.c
+++ b/clib/src/kdsource.c
@@ -34,8 +34,8 @@ void *KDS_calloc_i(int n_elem, size_t elem_size) {
   return KDS_calloc((size_t)(n_elem), elem_size);
 }
 
-double KDS_default_rngfct(void) {
-  // This is a horrible RNG:
+double KDS_default_rngfct(void*) {
+  // This is a horrible RNG. Also, simply uses global state!
   return rand() / (RAND_MAX + 1.0);
 }
 
@@ -278,13 +278,13 @@ KDSource *KDS_open(const char *xmlfilename) {
   return s;
 }
 
-int KDS_rand_sample2(kds_rng_fct_t rng, KDSource *kds, mcpl_particle_t *part,
+int KDS_rand_sample2(kds_rng_fct_t rng, void* rngstate, KDSource *kds, mcpl_particle_t *part,
                      int perturb, double w_crit, WeightFun bias, int loop) {
   int ret = 0;
   if (w_crit <= 0) {
     PList_get(kds->plist, part);
     if (perturb)
-      Geom_perturb(rng, kds->geom, part);
+      Geom_perturb(rng, rngstate, kds->geom, part);
     ret += PList_next(kds->plist, loop);
     ret += Geom_next(kds->geom, loop);
   } else { // Normalize w to 1
@@ -299,18 +299,18 @@ int KDS_rand_sample2(kds_rng_fct_t rng, KDSource *kds, mcpl_particle_t *part,
       if (part->weight * bs > w_crit) { // If w*bs>w_crit, use w_crit/w*bs as
                                         // prob of going forward in list
         if (perturb)
-          Geom_perturb(rng, kds->geom, part);
-        if (rng() < w_crit / (part->weight * bs)) {
+          Geom_perturb(rng, rngstate, kds->geom, part);
+        if (rng(rngstate) < w_crit / (part->weight * bs)) {
           ret += PList_next(kds->plist, loop);
           ret += Geom_next(kds->geom, loop);
         }
         break;
       } else { // If w*bs<w_crit, use w*bs/w_crit as prob of taking particle
         int take = 0;
-        if (rng() < (part->weight * bs) / w_crit) {
+        if (rng(rngstate) < (part->weight * bs) / w_crit) {
           take = 1;
           if (perturb)
-            Geom_perturb(rng, kds->geom, part);
+            Geom_perturb(rng, rngstate, kds->geom, part);
         }
         ret += PList_next(kds->plist, loop);
         ret += Geom_next(kds->geom, loop);
@@ -327,34 +327,34 @@ int KDS_rand_sample2(kds_rng_fct_t rng, KDSource *kds, mcpl_particle_t *part,
   return ret;
 }
 
-int KDS_rand_sample(kds_rng_fct_t rng, KDSource *kds, mcpl_particle_t *part) {
-  return KDS_rand_sample2(rng, kds, part, 1, 1, NULL, 1);
+int KDS_rand_sample(kds_rng_fct_t rng, void* rngstate, KDSource *kds, mcpl_particle_t *part) {
+  return KDS_rand_sample2(rng, rngstate, kds, part, 1, 1, NULL, 1);
 }
 
 int KDS_sample2(KDSource *kds, mcpl_particle_t *part, int perturb,
                 double w_crit, WeightFun bias, int loop) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return KDS_rand_sample2(rng, kds, part, perturb, w_crit, bias, loop);
+  return KDS_rand_sample2(rng, NULL, kds, part, perturb, w_crit, bias, loop);
 }
 
 int KDS_sample(KDSource *kds, mcpl_particle_t *part) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return KDS_rand_sample(rng, kds, part);
+  return KDS_rand_sample(rng, NULL, kds, part);
 }
 
 double KDS_w_mean(KDSource *kds, int N, WeightFun bias) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return KDS_rand_w_mean(rng, kds, N, bias);
+  return KDS_rand_w_mean(rng, NULL, kds, N, bias);
 }
 
-double KDS_rand_w_mean(kds_rng_fct_t rng, KDSource *kds, int N,
+double KDS_rand_w_mean(kds_rng_fct_t rng, void* rngstate, KDSource *kds, int N,
                        WeightFun bias) {
   int i;
   // char pt;
   mcpl_particle_t part;
   double w_mean = 0;
   for (i = 0; i < N; i++) {
-    KDS_rand_sample2(rng, kds, &part, 0, -1, NULL, 1);
+    KDS_rand_sample2(rng, rngstate, kds, &part, 0, -1, NULL, 1);
     if (bias)
       w_mean += part.weight * bias(&part);
     else
@@ -410,16 +410,16 @@ MultiSource *MS_open(int len, const char **xmlfilenames, const double *ws) {
   return result;
 }
 
-int MS_rand_sample2(kds_rng_fct_t rng, MultiSource *ms, mcpl_particle_t *part,
+int MS_rand_sample2(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, mcpl_particle_t *part,
                     int perturb, double w_crit, WeightFun bias, int loop) {
-  double y = rng();
+  double y = rng(rngstate);
   int i, ret;
   if (ms->cdf[ms->len - 1] <= 0)
     i = (int)(y * ms->len);
   else
     for (i = 0; y * ms->cdf[ms->len - 1] > ms->cdf[i]; i++)
       ;
-  ret = KDS_rand_sample2(rng, ms->s[i], part, perturb, w_crit, bias, loop);
+  ret = KDS_rand_sample2(rng, rngstate, ms->s[i], part, perturb, w_crit, bias, loop);
   if (ms->cdf[ms->len - 1] > 0)
     part->weight *= (ms->s[i]->J / ms->J) / (ms->ws[i] / ms->cdf[ms->len - 1]);
   else
@@ -427,32 +427,32 @@ int MS_rand_sample2(kds_rng_fct_t rng, MultiSource *ms, mcpl_particle_t *part,
   return ret;
 }
 
-int MS_rand_sample(kds_rng_fct_t rng, MultiSource *ms, mcpl_particle_t *part) {
-  return MS_rand_sample2(rng, ms, part, 1, 1, NULL, 1);
+int MS_rand_sample(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, mcpl_particle_t *part) {
+  return MS_rand_sample2(rng, rngstate, ms, part, 1, 1, NULL, 1);
 }
 
 int MS_sample(MultiSource *ms, mcpl_particle_t *part) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return MS_rand_sample(rng, ms, part);
+  return MS_rand_sample(rng, NULL, ms, part);
 }
 
 int MS_sample2(MultiSource *ms, mcpl_particle_t *part, int perturb,
                double w_crit, WeightFun bias, int loop) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return MS_rand_sample2(rng, ms, part, perturb, w_crit, bias, loop);
+  return MS_rand_sample2(rng, NULL, ms, part, perturb, w_crit, bias, loop);
 }
 
 double MS_w_mean(MultiSource *ms, int N, WeightFun bias) {
   kds_rng_fct_t rng = KDS_default_rngfct;
-  return MS_rand_w_mean(rng, ms, N, bias);
+  return MS_rand_w_mean(rng, NULL, ms, N, bias);
 }
 
-double MS_rand_w_mean(kds_rng_fct_t rng, MultiSource *ms, int N,
+double MS_rand_w_mean(kds_rng_fct_t rng, void* rngstate, MultiSource *ms, int N,
                       WeightFun bias) {
   double w_mean = 0;
   int i;
   for (i = 0; i < ms->len; i++)
-    w_mean += ms->ws[i] * KDS_rand_w_mean(rng, ms->s[i], N, bias);
+    w_mean += ms->ws[i] * KDS_rand_w_mean(rng, rngstate, ms->s[i], N, bias);
   return w_mean / ms->cdf[ms->len - 1];
 }
 

--- a/clib/src/resamplemcpl.c
+++ b/clib/src/resamplemcpl.c
@@ -4,8 +4,14 @@
 
 typedef double (*kds_stateless_rng_fct_t)(void);
 
+typedef struct {
+  kds_stateless_rng_fct_t rngfct;
+} kds_stateless_rng_fct_data_t;
+
 double kdsource_stateless_rng_wrapper(void *thefct_as_state) {
-  return ((kds_stateless_rng_fct_t)(thefct_as_state))();
+  kds_stateless_rng_fct_data_t *data =
+      (kds_stateless_rng_fct_data_t *)(thefct_as_state);
+  return data->rngfct();
 }
 
 void kdsource_resample_to_mcpl(kds_stateless_rng_fct_t rng_stateless,
@@ -15,7 +21,9 @@ void kdsource_resample_to_mcpl(kds_stateless_rng_fct_t rng_stateless,
   const char *outfilename = destination_mcpl;
 
   kds_rng_fct_t rng = kdsource_stateless_rng_wrapper;
-  void *rngstate = (void *)(rng_stateless);
+  kds_stateless_rng_fct_data_t rng_data;
+  rng_data.rngfct = rng_stateless;
+  void *rngstate = (void *)(&rng_data);
 
   KDSource *kds = KDS_open(filename);
 

--- a/clib/src/resamplemcpl.c
+++ b/clib/src/resamplemcpl.c
@@ -2,10 +2,21 @@
 #include "kdsource/kdsource.h"
 #include <stdint.h>
 
-void kdsource_resample_to_mcpl(kds_rng_fct_t rng, const char *kds_sourcefile,
+typedef double (*kds_stateless_rng_fct_t)(void);
+
+double kdsource_stateless_rng_wrapper( void * thefct_as_state )
+{
+  return ((kds_stateless_rng_fct_t)(thefct_as_state))();
+}
+
+void kdsource_resample_to_mcpl(kds_stateless_rng_fct_t rng_stateless,
+                               const char *kds_sourcefile,
                                const char *destination_mcpl, uint64_t nout) {
   const char *filename = kds_sourcefile;
   const char *outfilename = destination_mcpl;
+
+  kds_rng_fct_t rng = kdsource_stateless_rng_wrapper;
+  void * rngstate = (void*)(rng_stateless);
 
   KDSource *kds = KDS_open(filename);
 
@@ -20,7 +31,7 @@ void kdsource_resample_to_mcpl(kds_rng_fct_t rng, const char *kds_sourcefile,
   uint64_t i;
   mcpl_particle_t *part = mcpl_get_empty_particle(file);
   for (i = 0; i < nout; ++i) {
-    KDS_rand_sample2(rng, kds, part, 1, w_crit, NULL, 1);
+    KDS_rand_sample2(rng, rngstate, kds, part, 1, w_crit, NULL, 1);
     mcpl_add_particle(file, part);
   }
   mcpl_closeandgzip_outfile(file);

--- a/clib/src/resamplemcpl.c
+++ b/clib/src/resamplemcpl.c
@@ -4,8 +4,7 @@
 
 typedef double (*kds_stateless_rng_fct_t)(void);
 
-double kdsource_stateless_rng_wrapper( void * thefct_as_state )
-{
+double kdsource_stateless_rng_wrapper(void *thefct_as_state) {
   return ((kds_stateless_rng_fct_t)(thefct_as_state))();
 }
 
@@ -16,7 +15,7 @@ void kdsource_resample_to_mcpl(kds_stateless_rng_fct_t rng_stateless,
   const char *outfilename = destination_mcpl;
 
   kds_rng_fct_t rng = kdsource_stateless_rng_wrapper;
-  void * rngstate = (void*)(rng_stateless);
+  void *rngstate = (void *)(rng_stateless);
 
   KDSource *kds = KDS_open(filename);
 

--- a/clib/src/utils.c
+++ b/clib/src/utils.c
@@ -6,13 +6,14 @@
 
 #define KDS_PI 3.1415926535897932384626433832795028841971694
 
-void kds_rand_norm_twovals(kds_rng_fct_t rng, double *v1, double *v2) {
+void kds_rand_norm_twovals(kds_rng_fct_t rng, void* rngstate,
+                           double *v1, double *v2) {
   // sample two independent values from a unit normal distribution via the polar
   // method. The loop runs on average 4/pi ~= 1.27 times.
   double t, g1, g2;
   do {
-    g1 = 2.0 * rng() - 1.0;
-    g2 = 2.0 * rng() - 1.0;
+    g1 = 2.0 * rng(rngstate) - 1.0;
+    g2 = 2.0 * rng(rngstate) - 1.0;
     t = g1 * g1 + g2 * g2;
   } while (t >= 1.0 || t == 0.0);
   t = sqrt((-2.0 * log(t)) / t);
@@ -21,23 +22,23 @@ void kds_rand_norm_twovals(kds_rng_fct_t rng, double *v1, double *v2) {
 }
 
 // Sample with normal distribution (x0=0, s=1)
-double kds_rand_norm(kds_rng_fct_t rng) {
+double kds_rand_norm(kds_rng_fct_t rng, void* rngstate) {
   double v1, v2;
-  kds_rand_norm_twovals(rng, &v1, &v2);
+  kds_rand_norm_twovals(rng, rngstate, &v1, &v2);
   return v1;
 }
 
 // Sample with Epanechnikov distribution (x0=0, s=1)
-double kds_rand_epan(kds_rng_fct_t rng) {
+double kds_rand_epan(kds_rng_fct_t rng, void* rngstate) {
   // NB: Alternative simpler implementation:
   //   double x;
   //   do {
-  //     x = rng() * 2.0 - 1.0;
-  //   } while( rng() > 1.0 - x*x );
+  //     x = rng(rngstate) * 2.0 - 1.0;
+  //   } while( rng(rngstate) > 1.0 - x*x );
   //   return x;
-  double x1 = rng() * 2.0 - 1.0;
-  double x2 = rng() * 2.0 - 1.0;
-  double x3 = rng() * 2.0 - 1.0;
+  double x1 = rng(rngstate) * 2.0 - 1.0;
+  double x2 = rng(rngstate) * 2.0 - 1.0;
+  double x3 = rng(rngstate) * 2.0 - 1.0;
   if (fabs(x3) >= fabs(x2) && fabs(x3) >= fabs(x1))
     return x2;
   else
@@ -45,17 +46,17 @@ double kds_rand_epan(kds_rng_fct_t rng) {
 }
 
 // Sample with Tophat distribution (x0=0, s=1)
-double kds_rand_box(kds_rng_fct_t rng) { return rng() * 2.0 - 1.0; }
+double kds_rand_box(kds_rng_fct_t rng, void* rngstate) { return rng(rngstate) * 2.0 - 1.0; }
 
 // Sample depending on kernel selected
-double kds_rand_type(kds_rng_fct_t rng, char kernel) {
+double kds_rand_type(kds_rng_fct_t rng, void* rngstate, char kernel) {
   if (kernel == 'g') {
-    return kds_rand_norm(rng);
+    return kds_rand_norm(rng,rngstate);
   } else if (kernel == 'e') {
-    return kds_rand_epan(rng);
+    return kds_rand_epan(rng,rngstate);
   }
   if (kernel == 'b') {
-    return kds_rand_box(rng);
+    return kds_rand_box(rng,rngstate);
   } else {
     printf("Cannot perturbate with current kernel. \n");
     // KDS_error("Cannot perturbate with current kernel.");

--- a/clib/src/utils.c
+++ b/clib/src/utils.c
@@ -6,8 +6,8 @@
 
 #define KDS_PI 3.1415926535897932384626433832795028841971694
 
-void kds_rand_norm_twovals(kds_rng_fct_t rng, void* rngstate,
-                           double *v1, double *v2) {
+void kds_rand_norm_twovals(kds_rng_fct_t rng, void *rngstate, double *v1,
+                           double *v2) {
   // sample two independent values from a unit normal distribution via the polar
   // method. The loop runs on average 4/pi ~= 1.27 times.
   double t, g1, g2;
@@ -22,14 +22,14 @@ void kds_rand_norm_twovals(kds_rng_fct_t rng, void* rngstate,
 }
 
 // Sample with normal distribution (x0=0, s=1)
-double kds_rand_norm(kds_rng_fct_t rng, void* rngstate) {
+double kds_rand_norm(kds_rng_fct_t rng, void *rngstate) {
   double v1, v2;
   kds_rand_norm_twovals(rng, rngstate, &v1, &v2);
   return v1;
 }
 
 // Sample with Epanechnikov distribution (x0=0, s=1)
-double kds_rand_epan(kds_rng_fct_t rng, void* rngstate) {
+double kds_rand_epan(kds_rng_fct_t rng, void *rngstate) {
   // NB: Alternative simpler implementation:
   //   double x;
   //   do {
@@ -46,17 +46,19 @@ double kds_rand_epan(kds_rng_fct_t rng, void* rngstate) {
 }
 
 // Sample with Tophat distribution (x0=0, s=1)
-double kds_rand_box(kds_rng_fct_t rng, void* rngstate) { return rng(rngstate) * 2.0 - 1.0; }
+double kds_rand_box(kds_rng_fct_t rng, void *rngstate) {
+  return rng(rngstate) * 2.0 - 1.0;
+}
 
 // Sample depending on kernel selected
-double kds_rand_type(kds_rng_fct_t rng, void* rngstate, char kernel) {
+double kds_rand_type(kds_rng_fct_t rng, void *rngstate, char kernel) {
   if (kernel == 'g') {
-    return kds_rand_norm(rng,rngstate);
+    return kds_rand_norm(rng, rngstate);
   } else if (kernel == 'e') {
-    return kds_rand_epan(rng,rngstate);
+    return kds_rand_epan(rng, rngstate);
   }
   if (kernel == 'b') {
-    return kds_rand_box(rng,rngstate);
+    return kds_rand_box(rng, rngstate);
   } else {
     printf("Cannot perturbate with current kernel. \n");
     // KDS_error("Cannot perturbate with current kernel.");


### PR DESCRIPTION
Working on an updated KDSource component for McStas with @willend, we discovered that the new changes to the C API are not sufficient for McStas, since the RNG streams there are per-particle and a simple C function of signature `double()` is therefore not enough (it is OK for calling it from python or C++, but not if stuck with C).

Since 0.2.0 is very fresh and the conda packages are still not created, I simply went ahead and changed the API to also carry along a state (opaguely via a void pointer).

FYI A similar capability was added to NCrystal for the same reason https://github.com/mctools/ncrystal/releases/tag/v4.4.2

This is a relatively safe change at this point in time since I do not believe anyone had time to use the C-API of version0.2.0 I released last week, and since the python api is unchanged.